### PR TITLE
feat: add PTY leak detection

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ def mock_monitoring_report():
     report.windsurf_processes = []
     report.active_workspaces = []
     report.windsurf_launches_today = 3
+    report.pty_info = None
 
     # System info
     report.system = MagicMock()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,6 +26,7 @@ def mock_generate_report(mocker):
     mock_report.extensions_count = 10
     mock_report.mcp_servers_enabled = []
     mock_report.windsurf_processes = []
+    mock_report.pty_info = None
     return mocker.patch("surfmon.cli.generate_report", return_value=mock_report)
 
 
@@ -211,6 +212,10 @@ class TestCleanupCommand:
 
     def test_cleanup_windsurf_running(self, mocker):
         """Should warn when Windsurf is running."""
+        mock_paths = MagicMock()
+        mock_paths.app_name = "Windsurf.app"
+        mocker.patch("surfmon.config.get_paths", return_value=mock_paths)
+
         mock_proc = MagicMock()
         mock_proc.info = {
             "pid": 1234,
@@ -228,6 +233,10 @@ class TestCleanupCommand:
 
     def test_cleanup_with_orphans_cancelled(self, mocker):
         """Should handle cancelled cleanup."""
+        mock_paths = MagicMock()
+        mock_paths.app_name = "Windsurf.app"
+        mocker.patch("surfmon.config.get_paths", return_value=mock_paths)
+
         mock_proc = MagicMock()
         mock_proc.info = {
             "pid": 5678,
@@ -246,6 +255,10 @@ class TestCleanupCommand:
 
     def test_cleanup_with_force(self, mocker):
         """Should kill orphans with --force flag."""
+        mock_paths = MagicMock()
+        mock_paths.app_name = "Windsurf.app"
+        mocker.patch("surfmon.config.get_paths", return_value=mock_paths)
+
         mock_proc = MagicMock()
         mock_proc.info = {
             "pid": 5678,
@@ -502,6 +515,7 @@ class TestCreateSummaryTable:
         prev_report.process_count = 3
         prev_report.total_windsurf_memory_mb = 800.0
         prev_report.total_windsurf_cpu_percent = 8.0
+        prev_report.pty_info = None
 
         table = create_summary_table(report, prev_report)
         assert table is not None

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -22,6 +22,7 @@ def mock_report():
     report.windsurf_processes = []
     report.active_workspaces = []
     report.windsurf_launches_today = 3
+    report.pty_info = None
 
     # System info
     report.system = MagicMock()


### PR DESCRIPTION
## Summary

Detect Windsurf PTY (pseudo-terminal) leaks that can exhaust the system PTY limit (macOS default: 511). Windsurf can leak PTYs by not closing them when terminal sessions end, eventually preventing new terminals from being opened anywhere on the system.

## Changes

### PTY leak detection
- **`PtyInfo` dataclass** — holds Windsurf PTY count, system limit, and total system usage
- **`check_pty_leak()`** — queries `sysctl` for system PTY limit and `lsof /dev/ptmx` for current usage, filtering by Windsurf process name
- **Integrated into `generate_report()`** — PTY info included in every monitoring report with issue escalation:
  - ⚠️ Warning at ≥50 Windsurf PTYs
  - 🔴 Critical at ≥200 PTYs or ≥80% system usage

### Output
- **Rich table** — PTY row with color-coded count (green/yellow/red) and system usage
- **Markdown report** — PTY usage section with Windsurf and system counts
- **Watch mode** — PTY delta tracking (↑/↓) between reports

### Test fixes
- **Fix 3 pre-existing `TestCleanupCommand` failures** — tests hardcoded `Windsurf.app` paths but didn't mock `get_paths()`, causing failures when `SURFMON_TARGET=next`. Now mocks `surfmon.config.get_paths` for a stable `app_name`.

## Testing

- 8 new tests for PTY leak detection (`TestCheckPtyLeak`, `TestPtyLeakIssueDetection`)
- All 113 tests pass, coverage at 90.47%

## Stack

- ⬇️ #4 — chore: remove beads tracking system
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/surfmon/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
