### PR TITLE
chore: update copier-uv-bleeding template to 0.20.1

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier.
-_commit: 0.19.1
+_commit: 0.20.1
 _src_path: gh:detailobsessed/copier-uv-bleeding
 author_email: ismar@gmail.com
 author_fullname: Ismar Iljazovic

--- a/.github/ISSUE_TEMPLATE/1-bug.md
+++ b/.github/ISSUE_TEMPLATE/1-bug.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a bug report to help us improve.
 title: "bug: "
-labels: unconfirmed
+labels: bug
 assignees: [ichoosetoaccept]
 ---
 

--- a/.github/ISSUE_TEMPLATE/2-feature.md
+++ b/.github/ISSUE_TEMPLATE/2-feature.md
@@ -2,11 +2,11 @@
 name: Feature request
 about: Suggest an idea for this project.
 title: "feature: "
-labels: feature
+labels: enhancement
 assignees: [ichoosetoaccept]
 ---
 
-### Is your feature request related to a problem? Please describe.
+### Is your feature request related to a problem? Please describe
 <!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]. -->
 
 ### Describe the solution you'd like

--- a/.github/ISSUE_TEMPLATE/3-docs.md
+++ b/.github/ISSUE_TEMPLATE/3-docs.md
@@ -2,7 +2,7 @@
 name: Documentation update
 about: Point at unclear, missing or outdated documentation.
 title: "docs: "
-labels: docs
+labels: documentation
 assignees: [ichoosetoaccept]
 ---
 

--- a/.github/ISSUE_TEMPLATE/4-change.md
+++ b/.github/ISSUE_TEMPLATE/4-change.md
@@ -2,10 +2,11 @@
 name: Change request
 about: Suggest any other kind of change for this project.
 title: "change: "
+labels: enhancement
 assignees: [ichoosetoaccept]
 ---
 
-### Is your change request related to a problem? Please describe.
+### Is your change request related to a problem? Please describe
 <!-- A clear and concise description of what the problem is. -->
 
 ### Describe the solution you'd like

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
   quality:
     needs: changes
-    if: ${{ needs.changes.outputs.src == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.changes.outputs.src == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,8 +1,8 @@
 # Lychee link checker configuration
 # https://github.com/lycheeverse/lychee
 
-# Don't check the config file itself (regex patterns get parsed as URLs)
-exclude_path = [".lychee.toml"]
+# Exclude paths with non-URL content (Jinja templates, JSON reports, config)
+exclude_path = [".lychee.toml", "docs/.overrides", "reports"]
 
 # Exclude placeholder and example URLs
 exclude = [
@@ -13,7 +13,10 @@ exclude = [
     '^mailto:',
     '^https://github\.com/detailobsessed/surfmon',
     '^https://detailobsessed\.github\.io/surfmon',
+    '^http://localhost',
+    '^https://server\.codeium\.com',
 ]
+
 
 # Exclude local/private addresses
 exclude_all_private = true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at ismar@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <ismar@gmail.com>. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/src/surfmon/cli.py
+++ b/src/surfmon/cli.py
@@ -497,7 +497,7 @@ def prune(
 
     for json_file in json_files:
         try:
-            with open(json_file, encoding="utf-8") as f:
+            with json_file.open(encoding="utf-8") as f:
                 data = json.load(f)
 
             # Remove timestamp for comparison (it will always differ)
@@ -635,7 +635,7 @@ def analyze(
     reports = []
     for report_file in report_files:
         try:
-            with open(report_file, encoding="utf-8") as f:
+            with report_file.open(encoding="utf-8") as f:
                 data = json.load(f)
                 reports.append({
                     "timestamp": datetime.fromisoformat(data["timestamp"]),

--- a/src/surfmon/compare.py
+++ b/src/surfmon/compare.py
@@ -1,7 +1,10 @@
 """Compare two monitoring reports to show changes."""
 
 import json
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 from rich.console import Console
 from rich.panel import Panel
@@ -12,7 +15,7 @@ console = Console()
 
 def load_report(path: Path) -> dict:
     """Load a JSON report."""
-    with open(path, encoding="utf-8") as f:
+    with path.open(encoding="utf-8") as f:
         return json.load(f)
 
 

--- a/src/surfmon/monitor.py
+++ b/src/surfmon/monitor.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import json
+import operator
 import subprocess  # noqa: S404
 from dataclasses import asdict, dataclass
 from datetime import datetime
@@ -262,7 +263,7 @@ def get_mcp_config() -> list[str]:
         return []
 
     try:
-        with open(mcp_config_path, encoding="utf-8") as f:
+        with mcp_config_path.open(encoding="utf-8") as f:
             config = json.load(f)
             servers = config.get("mcpServers", {})
             return [name for name, cfg in servers.items() if not cfg.get("disabled", False)]
@@ -509,7 +510,7 @@ def check_log_issues() -> list[str]:
             if main_log.exists():
                 try:
                     # Only read last 50KB to avoid performance issues on large logs
-                    with open(main_log, encoding="utf-8") as f:
+                    with main_log.open(encoding="utf-8") as f:
                         f.seek(0, 2)  # Go to end
                         file_size = f.tell()
                         f.seek(max(0, file_size - 50000))  # Read last 50KB
@@ -547,7 +548,7 @@ def check_log_issues() -> list[str]:
             sharedprocess_log = latest_log / "sharedprocess.log"
             if sharedprocess_log.exists():
                 try:
-                    with open(sharedprocess_log, encoding="utf-8") as f:
+                    with sharedprocess_log.open(encoding="utf-8") as f:
                         f.seek(0, 2)
                         file_size = f.tell()
                         f.seek(max(0, file_size - 30000))
@@ -579,7 +580,7 @@ def check_log_issues() -> list[str]:
                             # Report top 3 problematic extensions
                             sorted_exts = sorted(
                                 extension_errors.items(),
-                                key=lambda x: x[1],
+                                key=operator.itemgetter(1),
                                 reverse=True,
                             )
                             ext_summary = ", ".join([f"{ext} ({count})" for ext, count in sorted_exts[:3]])
@@ -595,7 +596,7 @@ def check_log_issues() -> list[str]:
             network_log = latest_log / "network-shared.log"
             if network_log.exists():
                 try:
-                    with open(network_log, encoding="utf-8") as f:
+                    with network_log.open(encoding="utf-8") as f:
                         f.seek(0, 2)
                         file_size = f.tell()
                         f.seek(max(0, file_size - 30000))
@@ -636,7 +637,7 @@ def get_active_workspaces() -> list[WorkspaceInfo]:
     try:
         import re
 
-        with open(main_log, encoding="utf-8") as f:
+        with main_log.open(encoding="utf-8") as f:
             for line in f:
                 # Look for workspace load events
                 # Format: "WindsurfWindowsMainManager: Window will load
@@ -786,5 +787,5 @@ def generate_report() -> MonitoringReport:
 
 def save_report_json(report: MonitoringReport, output_path: Path) -> None:
     """Save report as JSON."""
-    with open(output_path, "w", encoding="utf-8") as f:
+    with output_path.open("w", encoding="utf-8") as f:
         json.dump(asdict(report), f, indent=2)

--- a/src/surfmon/output.py
+++ b/src/surfmon/output.py
@@ -1,13 +1,16 @@
 """Display and formatting utilities for monitoring reports."""
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
 from .config import get_target_display_name
-from .monitor import MonitoringReport
+
+if TYPE_CHECKING:
+    from .monitor import MonitoringReport
 
 console = Console()
 
@@ -234,8 +237,10 @@ def save_report_markdown(report: MonitoringReport, output_path: Path) -> None:
         "## Windsurf Resource Usage",
         "",
         f"- **Process Count:** {report.process_count}",
-        f"- **Total Memory:** {report.total_windsurf_memory_mb / 1024:.2f} GB "
-        f"({(report.total_windsurf_memory_mb / 1024 / report.system.total_memory_gb) * 100:.1f}% of system)",
+        (
+            f"- **Total Memory:** {report.total_windsurf_memory_mb / 1024:.2f} GB "
+            f"({(report.total_windsurf_memory_mb / 1024 / report.system.total_memory_gb) * 100:.1f}% of system)"
+        ),
         f"- **Total CPU:** {report.total_windsurf_cpu_percent:.1f}%",
         f"- **Extensions:** {report.extensions_count}",
         f"- **MCP Servers Enabled:** {len(report.mcp_servers_enabled)}",
@@ -294,5 +299,4 @@ def save_report_markdown(report: MonitoringReport, output_path: Path) -> None:
         lines.extend(f"- {issue}" for issue in report.log_issues)
         lines.append("")
 
-    with open(output_path, "w", encoding="utf-8") as f:
-        f.write("\n".join(lines))
+    Path(output_path).write_text("\n".join(lines), encoding="utf-8")


### PR DESCRIPTION
## Summary

Update copier-uv-bleeding template from 0.19.1 to 0.20.1, upgrade all dependencies, and fix lint issues.

## Changes

### Template update (copier)
- Bumped `.copier-answers.yml` to 0.20.1
- Updated issue templates with improved formatting
- Updated `setup-uv` action to v7.1.5 in CI workflow

### Lint fixes (ruff)
New ruff rules from the expanded rule set (FURB, TC, ISC, PTH) caught:
- **FURB118** — replaced lambda with `operator.itemgetter(1)` in `monitor.py`
- **TC001** — moved `MonitoringReport` import into `TYPE_CHECKING` block in `output.py`
- **ISC004** — parenthesized implicit string concatenation in list in `output.py`
- **PTH123** — replaced `open()` calls with `Path.open()` across `monitor.py` and `output.py`

### Lychee link checker fixes
- Added `localhost` and `server.codeium.com` to URL excludes
- Added `docs/.overrides` (Jinja templates) and `reports/` (JSON data) to path excludes
- Filed upstream: copier-uv-bleeding#155

### Dependency upgrade
- `uv lock --upgrade` — all deps bumped to latest

## Related Issues

- copier-uv-bleeding#155 — lychee fails on localhost in CONTRIBUTING.md
- copier-uv-bleeding#156 — dorny/paths-filter needs `pull-requests: read` on Blacksmith