### PR TITLE
fix: guard against ZeroDivisionError, fix process memory history alignment, extract helpers

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier.
-_commit: 0.20.1
+_commit: 0.20.3
 _src_path: gh:detailobsessed/copier-uv-bleeding
 author_email: ismar@gmail.com
 author_fullname: Ismar Iljazovic

--- a/.github/ISSUE_TEMPLATE/1-bug.md
+++ b/.github/ISSUE_TEMPLATE/1-bug.md
@@ -46,14 +46,11 @@ PASTE TRACEBACK HERE
 <!-- Please provide a clear and concise description of what you expected to happen. -->
 
 ### Environment information
-<!-- Please run the following command in your repository and paste its output below it,
-     redacting sensitive information. -->
+<!-- Please paste the output of `uv --version && python --version` and your OS below. -->
 
-```bash
-surfmon --debug-info  # | xclip -selection clipboard
 ```
-
-PASTE MARKDOWN OUTPUT HERE
+PASTE VERSION INFO HERE
+```
 
 ### Additional context
 <!-- Add any other relevant context about the problem here,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,16 @@ env:
   PYTHONWARNDEFAULTENCODING: "1"
   PYTHON_VERSIONS: ""
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
 
   changes:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      pull-requests: read
     outputs:
       src: ${{ steps.filter.outputs.src }}
     steps:
@@ -54,7 +60,7 @@ jobs:
       uses: lycheeverse/lychee-action@v2
       with:
         fail: true
-        args: --no-progress .
+        args: --config .lychee.toml --no-progress .
 
   quality:
     needs: changes

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -15,5 +15,6 @@ jobs:
     - name: Add needs-triage label
       run: gh issue edit "$NUMBER" --add-label "needs-triage"
       env:
+        GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,41 +14,14 @@ permissions:
 jobs:
   release:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    concurrency: release
-    environment: pypi
+    uses: detailobsessed/ci-components/.github/workflows/semantic-release-uv.yml@main
+    with:
+      python-version: "3.14"
+      pypi-publish: "false"
+    secrets: inherit
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-        fetch-tags: true
-
-    - name: Setup uv and Python
-      uses: astral-sh/setup-uv@v7.1.5
-      with:
-        python-version: "3.14"
-        enable-cache: true
-
-    - name: Install dependencies
-      run: uv sync --group maintain
-
-    - name: Semantic Release
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: uv run semantic-release version --changelog --push --tag --vcs-release
-
-    - name: Check if release artifacts exist
-      id: dist
-      shell: bash
-      run: |
-        if compgen -G "dist/*" > /dev/null; then
-          echo "has_dist=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "has_dist=false" >> "$GITHUB_OUTPUT"
-        fi
-
-    - name: Publish to PyPI
-      if: steps.dist.outputs.has_dist == 'true'
-      run: uv publish
+  # To enable PyPI publishing:
+  # 1. Re-run copier with publish_to_pypi=true
+  # 2. Set up trusted publisher on PyPI for detailobsessed/surfmon
+  #    - Workflow: release.yml, Environment: pypi
+  # 3. Create 'pypi' environment in GitHub repo settings

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -13,6 +13,7 @@ exclude = [
     '^mailto:',
     '^https://github\.com/detailobsessed/surfmon',
     '^https://detailobsessed\.github\.io/surfmon',
+    # Localhost URLs (e.g. docs preview in CONTRIBUTING.md)
     '^http://localhost',
     '^https://server\.codeium\.com',
 ]

--- a/prek.toml
+++ b/prek.toml
@@ -20,17 +20,17 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/detailobsessed/sync-with-uv"
-rev = ""  # prek autoupdate will fill this
+rev = "v0.6.0-prek"  # prek autoupdate will fill this
 hooks = [{ id = "sync-with-uv", priority = 0, stages = ["manual"] }]  # TODO: enable once fork supports prek.toml (copier-uv-bleeding#144)
 
 [[repos]]
 repo = "https://github.com/gitleaks/gitleaks"
-rev = ""  # prek autoupdate will fill this
+rev = "v8.30.0"  # prek autoupdate will fill this
 hooks = [{ id = "gitleaks", priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/astral-sh/ruff-pre-commit"
-rev = ""  # prek autoupdate will fill this
+rev = "v0.15.0"  # prek autoupdate will fill this
 hooks = [
   { id = "ruff", args = ["--fix"], priority = 1 },
   { id = "ruff-format", priority = 1 },
@@ -38,32 +38,32 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/astral-sh/uv-pre-commit"
-rev = ""  # prek autoupdate will fill this
+rev = "0.10.0"  # prek autoupdate will fill this
 hooks = [{ id = "uv-lock", priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/shellcheck-py/shellcheck-py"
-rev = ""  # prek autoupdate will fill this
+rev = "v0.11.0.1"  # prek autoupdate will fill this
 hooks = [{ id = "shellcheck", priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/rhysd/actionlint"
-rev = ""  # prek autoupdate will fill this
+rev = "v1.7.10"  # prek autoupdate will fill this
 hooks = [{ id = "actionlint", priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/crate-ci/typos"
-rev = ""  # prek autoupdate will fill this
+rev = "v1.43.3"  # prek autoupdate will fill this
 hooks = [{ id = "typos", priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/igorshubovych/markdownlint-cli"
-rev = ""  # prek autoupdate will fill this
+rev = "v0.47.0"  # prek autoupdate will fill this
 hooks = [{ id = "markdownlint", args = ["--fix"], priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"
-rev = "lychee-v0.22.0"
+rev = "lychee-v0.22.0"  # pinned: 'nightly' tag is mutable, update manually
 hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 1 }]
 
 [[repos]]
@@ -71,11 +71,12 @@ repo = "local"
 
 [[repos.hooks]]
 id = "no-commit-to-main"
-name = "prevent commits to main"
-entry = "bash -c 'test \"$(git rev-parse --abbrev-ref HEAD)\" != main || { echo Direct commits to main not allowed. Use a branch + PR. && exit 1; }'"
+name = "prevent pushes to main"
+entry = "bash -c 'test \"$(git rev-parse --abbrev-ref HEAD)\" != main || { echo Direct pushes to main not allowed. Use a branch + PR. && exit 1; }'"
 language = "system"
 always_run = true
 pass_filenames = false
+stages = ["pre-push"]
 priority = 0
 
 [[repos.hooks]]
@@ -108,7 +109,7 @@ stages = ["pre-push"]
 
 [[repos]]
 repo = "https://github.com/compilerla/conventional-pre-commit"
-rev = ""  # prek autoupdate will fill this
+rev = "v4.3.0"  # prek autoupdate will fill this
 hooks = [
   { id = "conventional-pre-commit", stages = ["commit-msg"], priority = 1, args = [
     "--strict",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,7 @@ source = ["src/", "tests/"]
 
 [tool.coverage.report]
 precision = 2
-omit = ["src/*/__init__.py", "src/*/__main__.py", "tests/__init__.py"]
+omit = ["src/*/__init__.py", "tests/__init__.py"]
 exclude_lines = ["pragma: no cover", "if TYPE_CHECKING", "if __name__ == .__main__.:"]
 
 [tool.coverage.json]
@@ -179,9 +179,9 @@ python-version = "3.14"
 setup = "uv sync"
 
 # Quality checks
-lint = "ruff check src tests"
-format = "ruff format src tests"
-typecheck = "ty check src tests"
+lint = "ruff check ."
+format = "ruff format ."
+typecheck = "ty check src"
 
 # Testing
 test = "pytest -m 'not slow'"
@@ -206,6 +206,7 @@ tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"
 # GitHub utilities
 releases = "gh release list --limit 10"
 runs = "gh run list --limit 10"
+checks = "gh pr checks --watch"
 watch = "gh run watch"
 
 [tool.semantic_release]

--- a/src/surfmon/output.py
+++ b/src/surfmon/output.py
@@ -1,6 +1,5 @@
 """Display and formatting utilities for monitoring reports."""
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from rich.console import Console
@@ -10,6 +9,8 @@ from rich.table import Table
 from .config import get_target_display_name
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from .monitor import MonitoringReport
 
 console = Console()
@@ -61,7 +62,7 @@ def display_report(report: MonitoringReport, verbose: bool = False) -> None:
     ws_table.add_row("Process Count", str(report.process_count))
 
     mem_gb = report.total_windsurf_memory_mb / 1024
-    mem_pct = (report.total_windsurf_memory_mb / 1024 / report.system.total_memory_gb) * 100
+    mem_pct = (mem_gb / report.system.total_memory_gb) * 100 if report.system.total_memory_gb > 0 else 0
     mem_color = "red" if mem_pct > 20 else "yellow" if mem_pct > 10 else "green"
     ws_table.add_row("Total Memory", f"[{mem_color}]{mem_gb:.2f} GB ({mem_pct:.1f}%)[/{mem_color}]")
 
@@ -240,6 +241,8 @@ def save_report_markdown(report: MonitoringReport, output_path: Path) -> None:
         (
             f"- **Total Memory:** {report.total_windsurf_memory_mb / 1024:.2f} GB "
             f"({(report.total_windsurf_memory_mb / 1024 / report.system.total_memory_gb) * 100:.1f}% of system)"
+            if report.system.total_memory_gb > 0
+            else f"- **Total Memory:** {report.total_windsurf_memory_mb / 1024:.2f} GB"
         ),
         f"- **Total CPU:** {report.total_windsurf_cpu_percent:.1f}%",
         f"- **Extensions:** {report.extensions_count}",
@@ -299,4 +302,4 @@ def save_report_markdown(report: MonitoringReport, output_path: Path) -> None:
         lines.extend(f"- {issue}" for issue in report.log_issues)
         lines.append("")
 
-    Path(output_path).write_text("\n".join(lines), encoding="utf-8")
+    output_path.write_text("\n".join(lines), encoding="utf-8")

--- a/tests/test_bugfixes.py
+++ b/tests/test_bugfixes.py
@@ -1,0 +1,175 @@
+"""Regression tests for bugs found in code review.
+
+Bug #1: ZeroDivisionError when system total_memory_gb is 0
+Bug #4: Operator precedence in process name simplification (latent, masked by guard)
+Bug #5: Late-appearing processes have misaligned memory history in plots
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class TestZeroDivisionWithZeroMemory:
+    """Bug #1: ZeroDivisionError when total_memory_gb is 0.
+
+    output.py:64, output.py:241, cli.py:110 all divide by
+    report.system.total_memory_gb without guarding against zero.
+    """
+
+    @pytest.fixture
+    def zero_memory_report(self):
+        """Report where system total_memory_gb is 0 (edge case)."""
+        report = MagicMock()
+        report.timestamp = "2025-01-01T12:00:00"
+        report.process_count = 5
+        report.total_windsurf_memory_mb = 1000.0
+        report.total_windsurf_cpu_percent = 10.0
+        report.extensions_count = 10
+        report.mcp_servers_enabled = []
+        report.language_servers = []
+        report.log_issues = []
+        report.windsurf_processes = []
+        report.active_workspaces = []
+        report.windsurf_launches_today = 1
+        report.pty_info = None
+        report.system = MagicMock()
+        report.system.total_memory_gb = 0.0
+        report.system.available_memory_gb = 0.0
+        report.system.memory_percent = 0.0
+        report.system.swap_used_gb = 0.0
+        report.system.swap_total_gb = 0.0
+        report.system.cpu_count = 4
+        return report
+
+    def test_display_report_zero_total_memory(self, zero_memory_report, mocker):
+        """display_report should handle zero total_memory_gb without ZeroDivisionError."""
+        from surfmon.output import display_report
+
+        mocker.patch("surfmon.output.console")
+        display_report(zero_memory_report)
+
+    def test_save_markdown_zero_total_memory(self, zero_memory_report, tmp_path):
+        """save_report_markdown should handle zero total_memory_gb without ZeroDivisionError."""
+        from surfmon.output import save_report_markdown
+
+        output_path = tmp_path / "report.md"
+        save_report_markdown(zero_memory_report, output_path)
+
+    def test_create_summary_table_zero_total_memory(self, zero_memory_report):
+        """create_summary_table should handle zero total_memory_gb without ZeroDivisionError."""
+        from surfmon.cli import create_summary_table
+
+        table = create_summary_table(zero_memory_report)
+        assert table is not None
+
+
+class TestProcessNameSimplification:
+    """Bug #4: Operator precedence in process name simplification.
+
+    cli.py:796 has a ternary with wrong precedence. Currently masked
+    by the outer if guard, but the redundant ternary should be removed
+    and the logic extracted for testability.
+    """
+
+    def test_helper_with_gpu_type(self):
+        """'Windsurf Helper (GPU)' → 'Windsurf Helper GPU'."""
+        from surfmon.cli import simplify_process_name
+
+        assert simplify_process_name("Windsurf Helper (GPU)") == "Windsurf Helper GPU"
+
+    def test_helper_with_renderer_type(self):
+        """'Windsurf Helper (Renderer)' → 'Windsurf Helper Renderer'."""
+        from surfmon.cli import simplify_process_name
+
+        assert simplify_process_name("Windsurf Helper (Renderer)") == "Windsurf Helper Renderer"
+
+    def test_helper_without_parens_unchanged(self):
+        """'Windsurf Helper' should not be mangled."""
+        from surfmon.cli import simplify_process_name
+
+        result = simplify_process_name("Windsurf Helper")
+        assert result == "Windsurf Helper"
+
+    def test_non_helper_unchanged(self):
+        """Non-helper names pass through unchanged."""
+        from surfmon.cli import simplify_process_name
+
+        assert simplify_process_name("Windsurf") == "Windsurf"
+        assert simplify_process_name("Electron") == "Electron"
+
+
+class TestProcessMemoryHistory:
+    """Bug #5: Late-appearing processes have misaligned memory history.
+
+    cli.py:800-807 doesn't insert leading zeros for processes that first
+    appear in later reports. Their data gets shifted left in plots.
+    """
+
+    def test_late_process_has_leading_zeros(self):
+        """Process appearing only in report 3 should have [0, 0, value]."""
+        from surfmon.cli import build_process_memory_history
+
+        reports = [
+            {"windsurf_processes": [{"name": "Windsurf", "memory_mb": 500}]},
+            {"windsurf_processes": [{"name": "Windsurf", "memory_mb": 600}]},
+            {
+                "windsurf_processes": [
+                    {"name": "Windsurf", "memory_mb": 700},
+                    {"name": "NewProc", "memory_mb": 200},
+                ]
+            },
+        ]
+
+        history = build_process_memory_history(reports)
+        assert history["NewProc"] == [0, 0, 200]
+
+    def test_all_histories_match_report_count(self):
+        """Every process history length should equal number of reports."""
+        from surfmon.cli import build_process_memory_history
+
+        reports = [
+            {"windsurf_processes": [{"name": "A", "memory_mb": 100}]},
+            {"windsurf_processes": [{"name": "B", "memory_mb": 200}]},
+            {
+                "windsurf_processes": [
+                    {"name": "A", "memory_mb": 150},
+                    {"name": "C", "memory_mb": 300},
+                ]
+            },
+        ]
+
+        history = build_process_memory_history(reports)
+        for name, mem_list in history.items():
+            assert len(mem_list) == len(reports), f"'{name}' has {len(mem_list)} entries, expected {len(reports)}"
+
+    def test_consistent_process_tracked_correctly(self):
+        """Process present in all reports should have correct values throughout."""
+        from surfmon.cli import build_process_memory_history
+
+        reports = [
+            {"windsurf_processes": [{"name": "Windsurf", "memory_mb": 500}]},
+            {"windsurf_processes": [{"name": "Windsurf", "memory_mb": 600}]},
+            {"windsurf_processes": [{"name": "Windsurf", "memory_mb": 700}]},
+        ]
+
+        history = build_process_memory_history(reports)
+        assert history["Windsurf"] == [500, 600, 700]
+
+    def test_disappearing_process_gets_trailing_zeros(self):
+        """Process that stops appearing should get trailing zeros."""
+        from surfmon.cli import build_process_memory_history
+
+        reports = [
+            {
+                "windsurf_processes": [
+                    {"name": "Windsurf", "memory_mb": 500},
+                    {"name": "TempProc", "memory_mb": 100},
+                ]
+            },
+            {"windsurf_processes": [{"name": "Windsurf", "memory_mb": 600}]},
+            {"windsurf_processes": [{"name": "Windsurf", "memory_mb": 700}]},
+        ]
+
+        history = build_process_memory_history(reports)
+        assert history["TempProc"] == [100, 0, 0]

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -680,7 +680,7 @@ class TestSaveReportJson:
         save_report_json(report, output_path)
 
         assert output_path.exists()
-        data = json.loads(output_path.read_text())
+        data = json.loads(output_path.read_text(encoding="utf-8"))
         assert data["timestamp"] == "2026-01-01"
         assert data["process_count"] == 5
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -138,7 +138,7 @@ class TestSaveReportMarkdown:
         save_report_markdown(mock_report, output_path)
 
         assert output_path.exists()
-        content = output_path.read_text()
+        content = output_path.read_text(encoding="utf-8")
         assert "# Windsurf Performance Report" in content
         assert "System Resources" in content
 
@@ -148,7 +148,7 @@ class TestSaveReportMarkdown:
         output_path = tmp_path / "report.md"
         save_report_markdown(mock_report, output_path)
 
-        content = output_path.read_text()
+        content = output_path.read_text(encoding="utf-8")
         assert "Issues Detected" in content
         assert "Critical issue" in content
 
@@ -157,7 +157,7 @@ class TestSaveReportMarkdown:
         output_path = tmp_path / "report.md"
         save_report_markdown(mock_report, output_path)
 
-        content = output_path.read_text()
+        content = output_path.read_text(encoding="utf-8")
         assert "MCP Servers" in content
         assert "server1" in content
 
@@ -174,5 +174,5 @@ class TestSaveReportMarkdown:
         output_path = tmp_path / "report.md"
         save_report_markdown(mock_report, output_path)
 
-        content = output_path.read_text()
+        content = output_path.read_text(encoding="utf-8")
         assert "Language Servers" in content


### PR DESCRIPTION
## Description

Fix bugs found during code review — all confirmed with regression tests written before fixes (TDD).

### Bug #1: `ZeroDivisionError` when `total_memory_gb` is 0

`display_report`, `save_report_markdown`, and `create_summary_table` all divide by `report.system.total_memory_gb` without guarding against zero. If psutil returns 0 for total memory (edge-case systems or partial failures), these crash.

**Fix:** Guard all three division sites with `> 0` check, defaulting to 0%.

### Bug #4: Latent operator precedence bug in process name simplification

```python
name = name.split("Helper")[0] + "Helper " + name.split("(")[1].split(")")[0] if "(" in name else name
```

The ternary binds tighter than `+`, so Python evaluates the last concatenation operand as the entire ternary — producing corrupted names when `"("` is absent. Currently masked by an outer `if "(" in name` guard, but fragile.

**Fix:** Extracted `simplify_process_name()` function, removed the redundant ternary entirely since the outer guard already ensures `"("` is present.

### Bug #5: Process memory history misalignment in plots

Late-appearing processes (e.g., a Helper that spawns mid-session) got their memory data shifted left in `analyze --plot` charts. The inline history-building code appended values without inserting leading zeros for reports before the process existed. The trailing pad (`while len < timestamps`) then added zeros at the *end*, making the spike appear at the wrong time.

**Fix:** Extracted `build_process_memory_history()` with correct leading-zero insertion for new processes using `[0.0] * report_idx`.

### Cleanup

- Removed redundant `Path()` wrapping in `output.py` (`output_path` is already a `Path`)
- Moved `Path` import to `TYPE_CHECKING` block (now only used in annotations)
- Removed unused `defaultdict` import from `analyze` plot block

## Test Plan

11 new regression tests in `tests/test_bugfixes.py`, all written **before** fixes and confirmed failing:

- **`TestZeroDivisionWithZeroMemory`** (3 tests): `display_report`, `save_report_markdown`, `create_summary_table` with `total_memory_gb=0`
- **`TestProcessNameSimplification`** (4 tests): Helper with/without parens, non-helper names
- **`TestProcessMemoryHistory`** (4 tests): late-appearing processes, disappearing processes, consistent tracking, length alignment

## Checklist

- [x] Tests added/updated
- [x] `poe check` passes
- [x] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-message-convention)