### PR TITLE
chore: update copier-uv-bleeding template to 0.22.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,17 +1,17 @@
 # Changes here will be overwritten by Copier.
-_commit: 0.20.3
+_commit: 0.22.0
 _src_path: gh:detailobsessed/copier-uv-bleeding
 author_email: ismar@gmail.com
 author_fullname: Ismar Iljazovic
 author_username: ichoosetoaccept
 copyright_license: MIT
-include_template_dev_scripts: false
+include_template_dev_scripts: true
 project_description: Monitor Windsurf and Windsurf Next resource usage and diagnose
     problems
 project_name: surfmon
 project_type: package
 project_visibility: public
-publish_to_pypi: false
+publish_to_pypi: true
 repository_host: github.com
 repository_namespace: detailobsessed
 repository_provider: github.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,15 @@ jobs:
   quality:
     needs: changes
     if: ${{ github.event_name == 'push' || needs.changes.outputs.src == 'true' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      matrix:
+        os:
+        - blacksmith-4vcpu-ubuntu-2404
+        - macos-latest
+        - blacksmith-4vcpu-windows-2025
+        python-version:
+        - "3.14"
+    runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout
@@ -77,7 +85,7 @@ jobs:
     - name: Setup uv and Python
       uses: astral-sh/setup-uv@v7.1.5
       with:
-        python-version: "3.14"
+        python-version: ${{ matrix.python-version }}
         enable-cache: true
         cache-dependency-glob: pyproject.toml
 
@@ -95,6 +103,7 @@ jobs:
 
     - name: Store objects inventory for tests
       uses: actions/upload-artifact@v6
+      if: ${{ matrix.os == 'blacksmith-4vcpu-ubuntu-2404' && matrix.python-version == '3.14' }}
       with:
         name: objects.inv
         path: site/objects.inv
@@ -103,7 +112,23 @@ jobs:
 
     needs:
     - quality
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      matrix:
+        os:
+        - blacksmith-4vcpu-ubuntu-2404
+        - macos-latest
+        - blacksmith-4vcpu-windows-2025
+        python-version:
+        - "3.14"
+        resolution:
+        - highest
+        - lowest-direct
+        exclude:
+        - os: macos-latest
+          resolution: lowest-direct
+        - os: blacksmith-4vcpu-windows-2025
+          resolution: lowest-direct
+    runs-on: ${{ matrix.os }}
     continue-on-error: true
 
     steps:
@@ -116,11 +141,14 @@ jobs:
     - name: Setup uv and Python
       uses: astral-sh/setup-uv@v7.1.5
       with:
-        python-version: "3.14"
+        python-version: ${{ matrix.python-version }}
         enable-cache: true
         cache-dependency-glob: pyproject.toml
+        cache-suffix: ${{ matrix.resolution }}
 
     - name: Install dependencies
+      env:
+        UV_RESOLUTION: ${{ matrix.resolution }}
       run: uv run poe setup
 
     - name: Download objects inventory
@@ -133,6 +161,7 @@ jobs:
       run: uv run poe test-cov
 
     - name: Upload coverage to Codecov
+      if: ${{ matrix.os == 'blacksmith-4vcpu-ubuntu-2404' && matrix.resolution == 'highest' }}
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,26 @@ jobs:
       pypi-publish: "false"
     secrets: inherit
 
-  # To enable PyPI publishing:
-  # 1. Re-run copier with publish_to_pypi=true
-  # 2. Set up trusted publisher on PyPI for detailobsessed/surfmon
-  #    - Workflow: release.yml, Environment: pypi
-  # 3. Create 'pypi' environment in GitHub repo settings
+  pypi-publish:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/surfmon
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+    - name: Checkout release tag
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ needs.release.outputs.version }}
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        python-version: "3.14"
+    - name: Build and publish
+      run: |
+        uv build
+        uv publish

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -26,7 +26,8 @@ exclude_all_private = true
 include_mail = false
 
 # Accept common status codes
-accept = [200, 204, 301, 302, 403, 429]
+# 502: GitHub commit/release URLs transiently return Bad Gateway
+accept = [200, 204, 301, 302, 403, 429, 502]
 
 # Timeout per request
 timeout = 30

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -21,3 +21,6 @@ MD041: false
 
 # Allow duplicate headings with different content (e.g., "Description" in multiple sections)
 MD024: false
+
+# Allow blank lines between consecutive blockquotes (used for callout boxes in README)
+MD028: false

--- a/prek.toml
+++ b/prek.toml
@@ -1,5 +1,7 @@
 default_stages = ["pre-commit"]
 minimum_prek_version = "0.3.2"
+# All available: commit-msg, post-checkout, post-commit, post-merge, post-rewrite, pre-commit, pre-merge-commit, pre-push, pre-rebase, prepare-commit-msg
+default_install_hook_types = ["commit-msg", "post-merge", "pre-commit", "pre-push"]
 
 [[repos]]
 repo = "builtin"
@@ -64,7 +66,7 @@ hooks = [{ id = "markdownlint", args = ["--fix"], priority = 1 }]
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"
 rev = "lychee-v0.22.0"  # pinned: 'nightly' tag is mutable, update manually
-hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 1 }]
+hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 1, types_or = ["markdown", "html", "rst", "yaml"] }]
 
 [[repos]]
 repo = "local"
@@ -106,6 +108,15 @@ language = "system"
 files = { glob = ["docs/**", "mkdocs.yml", "README.md", "CONTRIBUTING.md", "CHANGELOG.md", "src/**"] }
 pass_filenames = false
 stages = ["pre-push"]
+
+[[repos.hooks]]
+id = "check-template-update"
+name = "check for template updates"
+entry = "bash scripts/check-template-update.sh"
+language = "system"
+always_run = true
+pass_filenames = false
+stages = ["post-merge"]
 
 [[repos]]
 repo = "https://github.com/compilerla/conventional-pre-commit"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ ci = [
     "pytest-cov>=6",
     "pytest-randomly>=3.15",
     "ty>=0.0.14",
-    "poethepoet>=0.32",
+    "poethepoet>=0.41",
     "pytest-mock>=3.15.1",
 ]
 local = [
@@ -134,7 +134,7 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["S101"]  # Allow assert in tests
+"tests/**" = ["S101", "S603", "S607", "S701", "T201"]  # Allow assert, subprocess, jinja2, print in tests
 
 [tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false
@@ -155,7 +155,6 @@ markers = [
 ]
 filterwarnings = [
     "error",
-    "error::EncodingWarning",
 ]
 
 [tool.coverage.run]
@@ -181,7 +180,7 @@ setup = "uv sync"
 # Quality checks
 lint = "ruff check ."
 format = "ruff format ."
-typecheck = "ty check src"
+typecheck = "ty check ."
 
 # Testing
 test = "pytest -m 'not slow'"
@@ -189,7 +188,8 @@ test-all = "pytest"
 test-cov = "pytest --cov=src/surfmon --cov-report=term-missing --cov-report=html"
 
 # Combined tasks
-check = ["lint", "typecheck"]
+check.parallel = ["lint", "typecheck"]
+check.ignore_fail = "return_non_zero"
 fix = ["lint --fix", "format"]
 
 # Documentation
@@ -200,10 +200,18 @@ docs-deploy = "mkdocs gh-deploy"
 # Pre-commit
 prek = "prek run --all-files"
 
+# Template dev
+verify-scaffold = "bash scripts/verify-scaffold.sh"
+
+# Template utilities
+update-template = "copier update --trust . --skip-answered"
+
 # Git utilities
 tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"
 
 # GitHub utilities
+# actions-up: https://github.com/azat-io/actions-up
+actionsup = "actions-up"
 releases = "gh release list --limit 10"
 runs = "gh run list --limit 10"
 checks = "gh pr checks --watch"

--- a/scripts/check-template-update.sh
+++ b/scripts/check-template-update.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Check if a newer version of the copier template is available.
+# Runs as a post-merge hook — informational only, never blocks.
+set -euo pipefail
+
+answers=".copier-answers.yml"
+[[ -f "$answers" ]] || exit 0
+
+local_version=$(grep "^_commit:" "$answers" | sed "s/_commit: *//;s/^['\"]//;s/['\"]$//") || true
+src_path=$(grep "^_src_path:" "$answers" | sed "s/_src_path: *//;s/^['\"]//;s/['\"]$//") || true
+
+[[ -z "$local_version" || -z "$src_path" ]] && exit 0
+
+# Only supports GitHub for now — silently exit for other providers
+case "$src_path" in
+  gh:*|https://github.com/*) ;;
+  *) exit 0 ;;
+esac
+
+# Convert copier src_path to GitHub owner/repo
+repo="${src_path#gh:}"
+repo="${repo#https://github.com/}"
+repo="${repo%.git}"
+
+latest=$(curl -s --connect-timeout 3 --max-time 5 \
+  "https://api.github.com/repos/${repo}/releases/latest" \
+  | grep '"tag_name"' | sed 's/.*"tag_name": *"//;s/".*//') || true
+
+[[ -z "$latest" ]] && exit 0
+
+if [[ "$local_version" != "$latest" ]]; then
+  cyan='\033[0;36m'; yellow='\033[1;33m'; dim='\033[2m'; bold='\033[1m'; reset='\033[0m'
+  echo ""
+  echo -e "  ${cyan}ℹ️  Template update available:${reset} ${dim}${local_version}${reset} ${bold}→${reset} ${yellow}${latest}${reset}"
+  echo -e "  ${dim}Run:${reset} copier update --trust . --skip-answered"
+  echo -e "  ${dim}Or:${reset}  poe update-template"
+  echo ""
+fi

--- a/scripts/verify-scaffold.sh
+++ b/scripts/verify-scaffold.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# Verify that a copier-uv-bleeding scaffold meets all quality expectations.
+# Run from the project root: bash scripts/verify-scaffold.sh
+# Exit code 0 = all checks pass, non-zero = failures found.
+
+set -euo pipefail
+
+passed=0
+failed=0
+warnings=0
+
+pass() { printf "  ✅ %s\n" "$1"; passed=$((passed + 1)); }
+fail() { printf "  ❌ %s\n" "$1"; failed=$((failed + 1)); }
+warn() { printf "  ⚠️  %s\n" "$1"; warnings=$((warnings + 1)); }
+
+section() { printf "\n━━━ %s ━━━\n" "$1"; }
+
+# ---------------------------------------------------------------------------
+section "Project Structure"
+# ---------------------------------------------------------------------------
+
+# Core files
+for f in pyproject.toml README.md LICENSE CHANGELOG.md CONTRIBUTING.md \
+         CODE_OF_CONDUCT.md SECURITY.md .gitignore .envrc .env.example \
+         .copier-answers.yml prek.toml .editorconfig \
+         .markdownlint.yaml .lychee.toml mkdocs.yml; do
+    if [[ -f "$f" ]]; then pass "$f exists"; else fail "$f missing"; fi
+done
+
+# Source package marker (__init__.py required for editable installs)
+if compgen -G "src/*/__init__.py" > /dev/null 2>&1; then
+    pass "src/*/__init__.py exists"
+else
+    fail "src/*/__init__.py missing (required for uv sync / editable installs)"
+fi
+
+# Read copier answers for conditional checks
+repo_provider=$(grep 'repository_provider' .copier-answers.yml 2>/dev/null | sed 's/.*: *//' || echo "github.com")
+
+# Docs
+for f in docs/index.md docs/changelog.md docs/contributing.md docs/license.md \
+         docs/code_of_conduct.md docs/reference/api.md; do
+    if [[ -f "$f" ]]; then pass "$f exists"; else fail "$f missing"; fi
+done
+
+# Provider-specific files
+if [[ "$repo_provider" == "github.com" ]]; then
+    for f in .github/workflows/ci.yml .github/workflows/release.yml \
+             .github/workflows/copier-update.yml .github/dependabot.yml \
+             .github/FUNDING.yml .github/actionlint.yaml; do
+        if [[ -f "$f" ]]; then pass "$f exists"; else fail "$f missing"; fi
+    done
+    if [[ -d ".github/ISSUE_TEMPLATE" ]]; then pass "Issue templates dir exists"; else fail "Issue templates missing"; fi
+    if [[ -f ".github/pull_request_template.md" ]]; then pass "PR template exists"; else fail "PR template missing"; fi
+elif [[ "$repo_provider" == "gitlab.com" ]]; then
+    if [[ -f ".gitlab-ci.yml" ]]; then pass ".gitlab-ci.yml exists"; else fail ".gitlab-ci.yml missing"; fi
+fi
+
+# ---------------------------------------------------------------------------
+section "Security"
+# ---------------------------------------------------------------------------
+
+if grep -q '^\.env$' .gitignore; then
+    pass ".env is gitignored"
+else
+    fail ".env is NOT in .gitignore — secrets at risk"
+fi
+
+if grep -q '!\.env\.example' .gitignore; then
+    pass ".env.example is excluded from gitignore"
+else
+    fail ".env.example not excluded — it should be tracked"
+fi
+
+if grep -q 'detect-private-key' prek.toml; then
+    pass "detect-private-key hook present"
+else
+    fail "detect-private-key hook missing"
+fi
+
+if grep -q 'gitleaks' prek.toml; then
+    pass "gitleaks hook present"
+else
+    fail "gitleaks hook missing"
+fi
+
+if [[ -f "SECURITY.md" ]]; then
+    pass "SECURITY.md exists"
+else
+    fail "SECURITY.md missing — no vulnerability reporting policy"
+fi
+
+# ---------------------------------------------------------------------------
+section "Python / uv Configuration"
+# ---------------------------------------------------------------------------
+
+if grep -q 'requires-python.*3\.14' pyproject.toml; then
+    pass "requires-python >= 3.14"
+else
+    warn "requires-python is not 3.14+"
+fi
+
+if grep -q 'uv_build' pyproject.toml; then
+    pass "uv_build backend configured"
+else
+    fail "build backend is not uv_build"
+fi
+
+if grep -q 'default-groups' pyproject.toml; then
+    pass "dependency groups configured"
+else
+    fail "No dependency groups found"
+fi
+
+if [[ -f "uv.lock" ]]; then pass "uv.lock exists"; else warn "uv.lock missing — run uv sync"; fi
+if [[ -d ".venv" ]]; then pass ".venv exists"; else warn ".venv missing — run uv sync"; fi
+
+# ---------------------------------------------------------------------------
+section "Ruff Linting"
+# ---------------------------------------------------------------------------
+
+for rule in '"E"' '"F"' '"UP"' '"I"' '"B"' '"SIM"' '"S"' '"T20"' '"PT"' '"PERF"'; do
+    if grep -q "$rule" pyproject.toml; then
+        pass "Ruff rule $rule enabled"
+    else
+        fail "Ruff rule $rule not found"
+    fi
+done
+
+if grep -q 'per-file-ignores' pyproject.toml && grep -q '"S101"' pyproject.toml; then
+    pass "S101 (assert) allowed in tests"
+else
+    fail "S101 not exempted for tests"
+fi
+
+# ---------------------------------------------------------------------------
+section "Testing"
+# ---------------------------------------------------------------------------
+
+if grep -q 'pytest' pyproject.toml; then pass "pytest configured"; else fail "pytest not found"; fi
+if grep -q 'pytest-cov' pyproject.toml; then pass "pytest-cov configured"; else fail "pytest-cov not found"; fi
+if grep -q 'pytest-randomly' pyproject.toml; then pass "pytest-randomly configured"; else fail "pytest-randomly not found"; fi
+
+if grep -q 'branch = true' pyproject.toml; then
+    pass "Branch coverage enabled"
+else
+    fail "Branch coverage not enabled"
+fi
+
+# ---------------------------------------------------------------------------
+section "Type Checking"
+# ---------------------------------------------------------------------------
+
+if grep -q 'ty' pyproject.toml; then pass "ty type checker configured"; else fail "ty not found"; fi
+if grep -q 'python-version.*3\.14' pyproject.toml; then pass "ty targets Python 3.14"; else warn "ty python version mismatch"; fi
+
+# ---------------------------------------------------------------------------
+section "Pre-commit Hooks"
+# ---------------------------------------------------------------------------
+
+for hook in trailing-whitespace end-of-file-fixer check-yaml check-toml \
+            check-json check-added-large-files check-merge-conflict \
+            mixed-line-ending detect-private-key gitleaks ruff ruff-format \
+            uv-lock shellcheck typos markdownlint \
+            conventional-pre-commit; do
+    if grep -q "$hook" prek.toml; then
+        pass "Hook: $hook"
+    else
+        fail "Hook missing: $hook"
+    fi
+done
+
+# GitHub-only hooks
+if [[ "$repo_provider" == "github.com" ]]; then
+    if grep -q 'actionlint' prek.toml; then
+        pass "Hook: actionlint"
+    else
+        fail "Hook missing: actionlint"
+    fi
+fi
+
+# Local hooks
+if grep -q 'ty check' prek.toml; then
+    pass "Local hook: ty type checker"
+else
+    fail "Local hook missing: ty"
+fi
+
+if grep -q 'pytest.*cov-fail-under' prek.toml; then
+    pass "Local hook: pytest with coverage gate"
+else
+    fail "Local hook missing: pytest coverage gate"
+fi
+
+# ---------------------------------------------------------------------------
+section "CI Workflows"
+# ---------------------------------------------------------------------------
+
+ci=".github/workflows/ci.yml"
+if [ -f "$ci" ]; then
+    if grep -q 'ubuntu' "$ci" && grep -q 'macos' "$ci" && grep -q 'windows' "$ci"; then
+        pass "CI: multi-OS matrix (Linux, macOS, Windows)"
+    else
+        fail "CI: missing OS variants in matrix"
+    fi
+
+    if grep -q 'lowest-direct' "$ci"; then
+        pass "CI: resolution testing (highest + lowest-direct)"
+    else
+        fail "CI: no resolution testing"
+    fi
+
+    if grep -q 'concurrency' "$ci"; then
+        pass "CI: concurrency group configured"
+    else
+        warn "CI: no concurrency group"
+    fi
+
+    if grep -qi 'codecov\|coveralls\|coverage' "$ci"; then
+        pass "CI: coverage upload configured"
+    else
+        fail "CI: no coverage upload (Codecov/Coveralls) — coverage data goes nowhere"
+    fi
+elif [ -f ".gitlab-ci.yml" ]; then
+    pass "CI: GitLab CI configured"
+else
+    warn "CI: no CI workflow found"
+fi
+
+rel=".github/workflows/release.yml"
+if [ -f "$rel" ]; then
+    if grep -q 'semantic-release' "$rel"; then
+        pass "Release: semantic-release configured"
+    else
+        fail "Release: semantic-release not found"
+    fi
+
+    if grep -q 'uv publish' "$rel"; then
+        pass "Release: PyPI publishing configured"
+    else
+        warn "Release: no PyPI publishing step"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+section "Documentation"
+# ---------------------------------------------------------------------------
+
+if grep -q 'name: material' mkdocs.yml; then pass "MkDocs Material theme"; else fail "Not using Material theme"; fi
+if grep -q 'mkdocstrings' mkdocs.yml; then pass "mkdocstrings configured"; else fail "mkdocstrings missing"; fi
+if grep -q 'llmstxt' mkdocs.yml; then pass "llms.txt plugin enabled"; else warn "llms.txt plugin missing"; fi
+if grep -q 'git-revision-date' mkdocs.yml; then pass "Git revision date plugin"; else warn "Git revision date plugin missing"; fi
+
+# ---------------------------------------------------------------------------
+section "Poe Tasks"
+# ---------------------------------------------------------------------------
+
+for task in setup lint format typecheck test test-all test-cov check fix \
+            docs docs-build prek; do
+    if grep -q "^$task " pyproject.toml || grep -q "^$task = " pyproject.toml || grep -q "^$task\." pyproject.toml || grep -q "\[tool\.poe\.tasks\.$task\]" pyproject.toml; then
+        pass "Poe task: $task"
+    else
+        fail "Poe task missing: $task"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+section "README Quality"
+# ---------------------------------------------------------------------------
+
+if grep -q '\[!\[ci\]' README.md; then pass "CI badge present"; else warn "CI badge missing"; fi
+if grep -q '\[!\[release\]' README.md; then pass "Release badge present"; else warn "Release badge missing"; fi
+if grep -q '\[!\[documentation\]' README.md; then pass "Docs badge present"; else warn "Docs badge missing"; fi
+if grep -qi 'codecov\|coveralls\|coverage.*badge\|coverage.*img' README.md; then pass "Coverage badge present"; else fail "Coverage badge missing in README"; fi
+
+# Check for the known README formatting bug (#83)
+if grep -q '```##' README.md; then
+    fail "README: code fence merged with heading (no blank line) — copier-uv-bleeding#83"
+else
+    pass "README: no code fence / heading collision"
+fi
+
+# ---------------------------------------------------------------------------
+section "CONTRIBUTING.md Consistency"
+# ---------------------------------------------------------------------------
+
+if grep -q 'make setup' CONTRIBUTING.md; then
+    fail "CONTRIBUTING.md still references 'make setup' (no Makefile)"
+else
+    pass "CONTRIBUTING.md does not reference 'make setup'"
+fi
+
+if grep -q 'uv sync\|uv run' CONTRIBUTING.md; then
+    pass "CONTRIBUTING.md references uv commands"
+else
+    fail "CONTRIBUTING.md missing uv commands"
+fi
+
+# ---------------------------------------------------------------------------
+section "Markdown Lint"
+# ---------------------------------------------------------------------------
+
+if command -v markdownlint &>/dev/null; then
+    md_errors=$(markdownlint README.md CONTRIBUTING.md CHANGELOG.md 2>&1 || true)
+    if [[ -z "$md_errors" ]]; then
+        pass "Core .md files pass markdownlint"
+    else
+        fail "Markdownlint errors found:"
+        echo "$md_errors" | head -20 | sed 's/^/       /'
+    fi
+else
+    warn "markdownlint not installed — skipping"
+fi
+
+# ---------------------------------------------------------------------------
+section "Ruff Check (quick)"
+# ---------------------------------------------------------------------------
+
+if command -v ruff &>/dev/null || [[ -f ".venv/bin/ruff" ]]; then
+    ruff_bin="${VIRTUAL_ENV:-$PWD/.venv}/bin/ruff"
+    if [[ ! -x "$ruff_bin" ]]; then ruff_bin="ruff"; fi
+    if "$ruff_bin" check src &>/dev/null; then
+        pass "ruff check passes on src/"
+    else
+        ruff_errors=$("$ruff_bin" check src 2>&1 || true)
+        fail "ruff errors found:"
+        echo "$ruff_errors" | head -20 | sed 's/^/       /'
+    fi
+else
+    warn "ruff not available — skipping"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+printf "\n━━━ Summary ━━━\n"
+printf "  ✅ Passed:   %d\n" "$passed"
+printf "  ❌ Failed:   %d\n" "$failed"
+printf "  ⚠️  Warnings: %d\n" "$warnings"
+echo ""
+
+if ((failed > 0)); then
+    printf "🔴 %d check(s) failed.\n" "$failed"
+    exit 1
+else
+    printf "🟢 All checks passed"
+    if ((warnings > 0)); then printf " (%d warnings)" "$warnings"; fi
+    printf ".\n"
+    exit 0
+fi

--- a/uv.lock
+++ b/uv.lock
@@ -163,37 +163,41 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.13.3"
+version = "7.13.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/43/3e4ac666cc35f231fa70c94e9f38459299de1a152813f9d2f60fc5f3ecaf/coverage-7.13.3.tar.gz", hash = "sha256:f7f6182d3dfb8802c1747eacbfe611b669455b69b7c037484bb1efbbb56711ac", size = 826832, upload-time = "2026-02-03T14:02:30.944Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/56/95b7e30fa389756cb56630faa728da46a27b8c6eb46f9d557c68fff12b65/coverage-7.13.4.tar.gz", hash = "sha256:e5c8f6ed1e61a8b2dcdf31eb0b9bbf0130750ca79c1c49eb898e2ad86f5ccc91", size = 827239, upload-time = "2026-02-09T12:59:03.86Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/b3/677bb43427fed9298905106f39c6520ac75f746f81b8f01104526a8026e4/coverage-7.13.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c6f6169bbdbdb85aab8ac0392d776948907267fcc91deeacf6f9d55f7a83ae3b", size = 219513, upload-time = "2026-02-03T14:01:34.29Z" },
-    { url = "https://files.pythonhosted.org/packages/42/53/290046e3bbf8986cdb7366a42dab3440b9983711eaff044a51b11006c67b/coverage-7.13.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2f5e731627a3d5ef11a2a35aa0c6f7c435867c7ccbc391268eb4f2ca5dbdcc10", size = 219850, upload-time = "2026-02-03T14:01:35.984Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/2b/ab41f10345ba2e49d5e299be8663be2b7db33e77ac1b85cd0af985ea6406/coverage-7.13.3-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9db3a3285d91c0b70fab9f39f0a4aa37d375873677efe4e71e58d8321e8c5d39", size = 250886, upload-time = "2026-02-03T14:01:38.287Z" },
-    { url = "https://files.pythonhosted.org/packages/72/2d/b3f6913ee5a1d5cdd04106f257e5fac5d048992ffc2d9995d07b0f17739f/coverage-7.13.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:06e49c5897cb12e3f7ecdc111d44e97c4f6d0557b81a7a0204ed70a8b038f86f", size = 253393, upload-time = "2026-02-03T14:01:40.118Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/f6/b1f48810ffc6accf49a35b9943636560768f0812330f7456aa87dc39aff5/coverage-7.13.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb25061a66802df9fc13a9ba1967d25faa4dae0418db469264fd9860a921dde4", size = 254740, upload-time = "2026-02-03T14:01:42.413Z" },
-    { url = "https://files.pythonhosted.org/packages/57/d0/e59c54f9be0b61808f6bc4c8c4346bd79f02dd6bbc3f476ef26124661f20/coverage-7.13.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:99fee45adbb1caeb914da16f70e557fb7ff6ddc9e4b14de665bd41af631367ef", size = 250905, upload-time = "2026-02-03T14:01:44.163Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/f7/5291bcdf498bafbee3796bb32ef6966e9915aebd4d0954123c8eae921c32/coverage-7.13.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:318002f1fd819bdc1651c619268aa5bc853c35fa5cc6d1e8c96bd9cd6c828b75", size = 252753, upload-time = "2026-02-03T14:01:45.974Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/a9/1dcafa918c281554dae6e10ece88c1add82db685be123e1b05c2056ff3fb/coverage-7.13.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:71295f2d1d170b9977dc386d46a7a1b7cbb30e5405492529b4c930113a33f895", size = 250716, upload-time = "2026-02-03T14:01:48.844Z" },
-    { url = "https://files.pythonhosted.org/packages/44/bb/4ea4eabcce8c4f6235df6e059fbc5db49107b24c4bdffc44aee81aeca5a8/coverage-7.13.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5b1ad2e0dc672625c44bc4fe34514602a9fd8b10d52ddc414dc585f74453516c", size = 250530, upload-time = "2026-02-03T14:01:50.793Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/31/4a6c9e6a71367e6f923b27b528448c37f4e959b7e4029330523014691007/coverage-7.13.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b2beb64c145593a50d90db5c7178f55daeae129123b0d265bdb3cbec83e5194a", size = 252186, upload-time = "2026-02-03T14:01:52.607Z" },
-    { url = "https://files.pythonhosted.org/packages/27/92/e1451ef6390a4f655dc42da35d9971212f7abbbcad0bdb7af4407897eb76/coverage-7.13.3-cp314-cp314-win32.whl", hash = "sha256:3d1aed4f4e837a832df2f3b4f68a690eede0de4560a2dbc214ea0bc55aabcdb4", size = 222253, upload-time = "2026-02-03T14:01:55.071Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/98/78885a861a88de020c32a2693487c37d15a9873372953f0c3c159d575a43/coverage-7.13.3-cp314-cp314-win_amd64.whl", hash = "sha256:9f9efbbaf79f935d5fbe3ad814825cbce4f6cdb3054384cb49f0c0f496125fa0", size = 223069, upload-time = "2026-02-03T14:01:56.95Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/fb/3784753a48da58a5337972abf7ca58b1fb0f1bda21bc7b4fae992fd28e47/coverage-7.13.3-cp314-cp314-win_arm64.whl", hash = "sha256:31b6e889c53d4e6687ca63706148049494aace140cffece1c4dc6acadb70a7b3", size = 221633, upload-time = "2026-02-03T14:01:58.758Z" },
-    { url = "https://files.pythonhosted.org/packages/40/f9/75b732d9674d32cdbffe801ed5f770786dd1c97eecedef2125b0d25102dc/coverage-7.13.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c5e9787cec750793a19a28df7edd85ac4e49d3fb91721afcdc3b86f6c08d9aa8", size = 220243, upload-time = "2026-02-03T14:02:01.109Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/7e/2868ec95de5a65703e6f0c87407ea822d1feb3619600fbc3c1c4fa986090/coverage-7.13.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e5b86db331c682fd0e4be7098e6acee5e8a293f824d41487c667a93705d415ca", size = 220515, upload-time = "2026-02-03T14:02:02.862Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/eb/9f0d349652fced20bcaea0f67fc5777bd097c92369f267975732f3dc5f45/coverage-7.13.3-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:edc7754932682d52cf6e7a71806e529ecd5ce660e630e8bd1d37109a2e5f63ba", size = 261874, upload-time = "2026-02-03T14:02:04.727Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/a5/6619bc4a6c7b139b16818149a3e74ab2e21599ff9a7b6811b6afde99f8ec/coverage-7.13.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d3a16d6398666510a6886f67f43d9537bfd0e13aca299688a19daa84f543122f", size = 264004, upload-time = "2026-02-03T14:02:06.634Z" },
-    { url = "https://files.pythonhosted.org/packages/29/b7/90aa3fc645a50c6f07881fca4fd0ba21e3bfb6ce3a7078424ea3a35c74c9/coverage-7.13.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:303d38b19626c1981e1bb067a9928236d88eb0e4479b18a74812f05a82071508", size = 266408, upload-time = "2026-02-03T14:02:09.037Z" },
-    { url = "https://files.pythonhosted.org/packages/62/55/08bb2a1e4dcbae384e638f0effef486ba5987b06700e481691891427d879/coverage-7.13.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:284e06eadfe15ddfee2f4ee56631f164ef897a7d7d5a15bca5f0bb88889fc5ba", size = 260977, upload-time = "2026-02-03T14:02:11.755Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/76/8bd4ae055a42d8fb5dd2230e5cf36ff2e05f85f2427e91b11a27fea52ed7/coverage-7.13.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d401f0864a1d3198422816878e4e84ca89ec1c1bf166ecc0ae01380a39b888cd", size = 263868, upload-time = "2026-02-03T14:02:13.565Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/f9/ba000560f11e9e32ec03df5aa8477242c2d95b379c99ac9a7b2e7fbacb1a/coverage-7.13.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3f379b02c18a64de78c4ccdddf1c81c2c5ae1956c72dacb9133d7dd7809794ab", size = 261474, upload-time = "2026-02-03T14:02:16.069Z" },
-    { url = "https://files.pythonhosted.org/packages/90/4b/4de4de8f9ca7af4733bfcf4baa440121b7dbb3856daf8428ce91481ff63b/coverage-7.13.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:7a482f2da9086971efb12daca1d6547007ede3674ea06e16d7663414445c683e", size = 260317, upload-time = "2026-02-03T14:02:17.996Z" },
-    { url = "https://files.pythonhosted.org/packages/05/71/5cd8436e2c21410ff70be81f738c0dddea91bcc3189b1517d26e0102ccb3/coverage-7.13.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:562136b0d401992118d9b49fbee5454e16f95f85b120a4226a04d816e33fe024", size = 262635, upload-time = "2026-02-03T14:02:20.405Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/f8/2834bb45bdd70b55a33ec354b8b5f6062fc90e5bb787e14385903a979503/coverage-7.13.3-cp314-cp314t-win32.whl", hash = "sha256:ca46e5c3be3b195098dd88711890b8011a9fa4feca942292bb84714ce5eab5d3", size = 223035, upload-time = "2026-02-03T14:02:22.323Z" },
-    { url = "https://files.pythonhosted.org/packages/26/75/f8290f0073c00d9ae14056d2b84ab92dff21d5370e464cb6cb06f52bf580/coverage-7.13.3-cp314-cp314t-win_amd64.whl", hash = "sha256:06d316dbb3d9fd44cca05b2dbcfbef22948493d63a1f28e828d43e6cc505fed8", size = 224142, upload-time = "2026-02-03T14:02:24.143Z" },
-    { url = "https://files.pythonhosted.org/packages/03/01/43ac78dfea8946c4a9161bbc034b5549115cb2b56781a4b574927f0d141a/coverage-7.13.3-cp314-cp314t-win_arm64.whl", hash = "sha256:299d66e9218193f9dc6e4880629ed7c4cd23486005166247c283fb98531656c3", size = 222166, upload-time = "2026-02-03T14:02:26.005Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/fb/70af542d2d938c778c9373ce253aa4116dbe7c0a5672f78b2b2ae0e1b94b/coverage-7.13.3-py3-none-any.whl", hash = "sha256:90a8af9dba6429b2573199622d72e0ebf024d6276f16abce394ad4d181bb0910", size = 211237, upload-time = "2026-02-03T14:02:27.986Z" },
+    { url = "https://files.pythonhosted.org/packages/92/11/a9cf762bb83386467737d32187756a42094927150c3e107df4cb078e8590/coverage-7.13.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:300deaee342f90696ed186e3a00c71b5b3d27bffe9e827677954f4ee56969601", size = 219522, upload-time = "2026-02-09T12:58:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/28/56e6d892b7b052236d67c95f1936b6a7cf7c3e2634bf27610b8cbd7f9c60/coverage-7.13.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29e3220258d682b6226a9b0925bc563ed9a1ebcff3cad30f043eceea7eaf2689", size = 219855, upload-time = "2026-02-09T12:58:10.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/69/233459ee9eb0c0d10fcc2fe425a029b3fa5ce0f040c966ebce851d030c70/coverage-7.13.4-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:391ee8f19bef69210978363ca930f7328081c6a0152f1166c91f0b5fdd2a773c", size = 250887, upload-time = "2026-02-09T12:58:12.503Z" },
+    { url = "https://files.pythonhosted.org/packages/06/90/2cdab0974b9b5bbc1623f7876b73603aecac11b8d95b85b5b86b32de5eab/coverage-7.13.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0dd7ab8278f0d58a0128ba2fca25824321f05d059c1441800e934ff2efa52129", size = 253396, upload-time = "2026-02-09T12:58:14.615Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/15/ea4da0f85bf7d7b27635039e649e99deb8173fe551096ea15017f7053537/coverage-7.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78cdf0d578b15148b009ccf18c686aa4f719d887e76e6b40c38ffb61d264a552", size = 254745, upload-time = "2026-02-09T12:58:16.162Z" },
+    { url = "https://files.pythonhosted.org/packages/99/11/bb356e86920c655ca4d61daee4e2bbc7258f0a37de0be32d233b561134ff/coverage-7.13.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:48685fee12c2eb3b27c62f2658e7ea21e9c3239cba5a8a242801a0a3f6a8c62a", size = 257055, upload-time = "2026-02-09T12:58:17.892Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/0f/9ae1f8cb17029e09da06ca4e28c9e1d5c1c0a511c7074592e37e0836c915/coverage-7.13.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4e83efc079eb39480e6346a15a1bcb3e9b04759c5202d157e1dd4303cd619356", size = 250911, upload-time = "2026-02-09T12:58:19.495Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3a/adfb68558fa815cbc29747b553bc833d2150228f251b127f1ce97e48547c/coverage-7.13.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecae9737b72408d6a950f7e525f30aca12d4bd8dd95e37342e5beb3a2a8c4f71", size = 252754, upload-time = "2026-02-09T12:58:21.064Z" },
+    { url = "https://files.pythonhosted.org/packages/32/b1/540d0c27c4e748bd3cd0bd001076ee416eda993c2bae47a73b7cc9357931/coverage-7.13.4-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ae4578f8528569d3cf303fef2ea569c7f4c4059a38c8667ccef15c6e1f118aa5", size = 250720, upload-time = "2026-02-09T12:58:22.622Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/95/383609462b3ffb1fe133014a7c84fc0dd01ed55ac6140fa1093b5af7ebb1/coverage-7.13.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:6fdef321fdfbb30a197efa02d48fcd9981f0d8ad2ae8903ac318adc653f5df98", size = 254994, upload-time = "2026-02-09T12:58:24.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ba/1761138e86c81680bfc3c49579d66312865457f9fe405b033184e5793cb3/coverage-7.13.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b0f6ccf3dbe577170bebfce1318707d0e8c3650003cb4b3a9dd744575daa8b5", size = 250531, upload-time = "2026-02-09T12:58:26.271Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/8e/05900df797a9c11837ab59c4d6fe94094e029582aab75c3309a93e6fb4e3/coverage-7.13.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75fcd519f2a5765db3f0e391eb3b7d150cce1a771bf4c9f861aeab86c767a3c0", size = 252189, upload-time = "2026-02-09T12:58:27.807Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bd/29c9f2db9ea4ed2738b8a9508c35626eb205d51af4ab7bf56a21a2e49926/coverage-7.13.4-cp314-cp314-win32.whl", hash = "sha256:8e798c266c378da2bd819b0677df41ab46d78065fb2a399558f3f6cae78b2fbb", size = 222258, upload-time = "2026-02-09T12:58:29.441Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/4d/1f8e723f6829977410efeb88f73673d794075091c8c7c18848d273dc9d73/coverage-7.13.4-cp314-cp314-win_amd64.whl", hash = "sha256:245e37f664d89861cf2329c9afa2c1fe9e6d4e1a09d872c947e70718aeeac505", size = 223073, upload-time = "2026-02-09T12:58:31.026Z" },
+    { url = "https://files.pythonhosted.org/packages/51/5b/84100025be913b44e082ea32abcf1afbf4e872f5120b7a1cab1d331b1e13/coverage-7.13.4-cp314-cp314-win_arm64.whl", hash = "sha256:ad27098a189e5838900ce4c2a99f2fe42a0bf0c2093c17c69b45a71579e8d4a2", size = 221638, upload-time = "2026-02-09T12:58:32.599Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/e4/c884a405d6ead1370433dad1e3720216b4f9fd8ef5b64bfd984a2a60a11a/coverage-7.13.4-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:85480adfb35ffc32d40918aad81b89c69c9cc5661a9b8a81476d3e645321a056", size = 220246, upload-time = "2026-02-09T12:58:34.181Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5c/4d7ed8b23b233b0fffbc9dfec53c232be2e695468523242ea9fd30f97ad2/coverage-7.13.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79be69cf7f3bf9b0deeeb062eab7ac7f36cd4cc4c4dd694bd28921ba4d8596cc", size = 220514, upload-time = "2026-02-09T12:58:35.704Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6f/3284d4203fd2f28edd73034968398cd2d4cb04ab192abc8cff007ea35679/coverage-7.13.4-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:caa421e2684e382c5d8973ac55e4f36bed6821a9bad5c953494de960c74595c9", size = 261877, upload-time = "2026-02-09T12:58:37.864Z" },
+    { url = "https://files.pythonhosted.org/packages/09/aa/b672a647bbe1556a85337dc95bfd40d146e9965ead9cc2fe81bde1e5cbce/coverage-7.13.4-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14375934243ee05f56c45393fe2ce81fe5cc503c07cee2bdf1725fb8bef3ffaf", size = 264004, upload-time = "2026-02-09T12:58:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/79/a1/aa384dbe9181f98bba87dd23dda436f0c6cf2e148aecbb4e50fc51c1a656/coverage-7.13.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25a41c3104d08edb094d9db0d905ca54d0cd41c928bb6be3c4c799a54753af55", size = 266408, upload-time = "2026-02-09T12:58:41.852Z" },
+    { url = "https://files.pythonhosted.org/packages/53/5e/5150bf17b4019bc600799f376bb9606941e55bd5a775dc1e096b6ffea952/coverage-7.13.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f01afcff62bf9a08fb32b2c1d6e924236c0383c02c790732b6537269e466a72", size = 267544, upload-time = "2026-02-09T12:58:44.093Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ed/f1de5c675987a4a7a672250d2c5c9d73d289dbf13410f00ed7181d8017dd/coverage-7.13.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:eb9078108fbf0bcdde37c3f4779303673c2fa1fe8f7956e68d447d0dd426d38a", size = 260980, upload-time = "2026-02-09T12:58:45.721Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/e3/fe758d01850aa172419a6743fe76ba8b92c29d181d4f676ffe2dae2ba631/coverage-7.13.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e086334e8537ddd17e5f16a344777c1ab8194986ec533711cbe6c41cde841b6", size = 263871, upload-time = "2026-02-09T12:58:47.334Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/76/b829869d464115e22499541def9796b25312b8cf235d3bb00b39f1675395/coverage-7.13.4-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:725d985c5ab621268b2edb8e50dfe57633dc69bda071abc470fed55a14935fd3", size = 261472, upload-time = "2026-02-09T12:58:48.995Z" },
+    { url = "https://files.pythonhosted.org/packages/14/9e/caedb1679e73e2f6ad240173f55218488bfe043e38da577c4ec977489915/coverage-7.13.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:3c06f0f1337c667b971ca2f975523347e63ec5e500b9aa5882d91931cd3ef750", size = 265210, upload-time = "2026-02-09T12:58:51.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/10/0dd02cb009b16ede425b49ec344aba13a6ae1dc39600840ea6abcb085ac4/coverage-7.13.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:590c0ed4bf8e85f745e6b805b2e1c457b2e33d5255dd9729743165253bc9ad39", size = 260319, upload-time = "2026-02-09T12:58:53.081Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8e/234d2c927af27c6d7a5ffad5bd2cf31634c46a477b4c7adfbfa66baf7ebb/coverage-7.13.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eb30bf180de3f632cd043322dad5751390e5385108b2807368997d1a92a509d0", size = 262638, upload-time = "2026-02-09T12:58:55.258Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/64/e5547c8ff6964e5965c35a480855911b61509cce544f4d442caa759a0702/coverage-7.13.4-cp314-cp314t-win32.whl", hash = "sha256:c4240e7eded42d131a2d2c4dec70374b781b043ddc79a9de4d55ca71f8e98aea", size = 223040, upload-time = "2026-02-09T12:58:56.936Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/96/38086d58a181aac86d503dfa9c47eb20715a79c3e3acbdf786e92e5c09a8/coverage-7.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4c7d3cc01e7350f2f0f6f7036caaf5673fb56b6998889ccfe9e1c1fe75a9c932", size = 224148, upload-time = "2026-02-09T12:58:58.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/72/8d10abd3740a0beb98c305e0c3faf454366221c0f37a8bcf8f60020bb65a/coverage-7.13.4-cp314-cp314t-win_arm64.whl", hash = "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b", size = 222172, upload-time = "2026-02-09T12:59:00.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/4a/331fe2caf6799d591109bb9c08083080f6de90a823695d412a935622abb2/coverage-7.13.4-py3-none-any.whl", hash = "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0", size = 211242, upload-time = "2026-02-09T12:59:02.032Z" },
 ]
 
 [[package]]
@@ -295,14 +299,34 @@ wheels = [
 
 [[package]]
 name = "griffe"
-version = "1.15.0"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffecli" },
+    { name = "griffelib" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/94/ee21d41e7eb4f823b94603b9d40f86d3c7fde80eacc2c3c71845476dddaa/griffe-2.0.0-py3-none-any.whl", hash = "sha256:5418081135a391c3e6e757a7f3f156f1a1a746cc7b4023868ff7d5e2f9a980aa", size = 5214, upload-time = "2026-02-09T19:09:44.105Z" },
+]
+
+[[package]]
+name = "griffecli"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama" },
+    { name = "griffelib" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/0c/3a471b6e31951dce2360477420d0a8d1e00dea6cf33b70f3e8c3ab6e28e1/griffe-1.15.0.tar.gz", hash = "sha256:7726e3afd6f298fbc3696e67958803e7ac843c1cfe59734b6251a40cdbfb5eea", size = 424112, upload-time = "2025-11-10T15:03:15.52Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl", hash = "sha256:6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3", size = 150705, upload-time = "2025-11-10T15:03:13.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ed/d93f7a447bbf7a935d8868e9617cbe1cadf9ee9ee6bd275d3040fbf93d60/griffecli-2.0.0-py3-none-any.whl", hash = "sha256:9f7cd9ee9b21d55e91689358978d2385ae65c22f307a63fb3269acf3f21e643d", size = 9345, upload-time = "2026-02-09T19:09:42.554Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
 
 [[package]]
@@ -394,11 +418,11 @@ wheels = [
 
 [[package]]
 name = "markdown"
-version = "3.10.1"
+version = "3.10.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b7/b1/af95bcae8549f1f3fd70faacb29075826a0d689a27f232e8cee315efa053/markdown-3.10.1.tar.gz", hash = "sha256:1c19c10bd5c14ac948c53d0d762a04e2fa35a6d58a6b7b1e6bfcbe6fefc0001a", size = 365402, upload-time = "2026-01-21T18:09:28.206Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/1b/6ef961f543593969d25b2afe57a3564200280528caa9bd1082eecdd7b3bc/markdown-3.10.1-py3-none-any.whl", hash = "sha256:867d788939fe33e4b736426f5b9f651ad0c0ae0ecf89df0ca5d1176c70812fe3", size = 107684, upload-time = "2026-01-21T18:09:27.203Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
 ]
 
 [[package]]
@@ -732,16 +756,16 @@ python = [
 
 [[package]]
 name = "mkdocstrings-python"
-version = "2.0.1"
+version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffe" },
     { name = "mkdocs-autorefs" },
     { name = "mkdocstrings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/75/d30af27a2906f00eb90143470272376d728521997800f5dce5b340ba35bc/mkdocstrings_python-2.0.1.tar.gz", hash = "sha256:843a562221e6a471fefdd4b45cc6c22d2607ccbad632879234fa9692e9cf7732", size = 199345, upload-time = "2025-12-03T14:26:11.755Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/84/78243847ad9d5c21d30a2842720425b17e880d99dfe824dee11d6b2149b4/mkdocstrings_python-2.0.2.tar.gz", hash = "sha256:4a32ccfc4b8d29639864698e81cfeb04137bce76bb9f3c251040f55d4b6e1ad8", size = 199124, upload-time = "2026-02-09T15:12:01.543Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/06/c5f8deba7d2cbdfa7967a716ae801aa9ca5f734b8f54fd473ef77a088dbe/mkdocstrings_python-2.0.1-py3-none-any.whl", hash = "sha256:66ecff45c5f8b71bf174e11d49afc845c2dfc7fc0ab17a86b6b337e0f24d8d90", size = 105055, upload-time = "2025-12-03T14:26:10.184Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/31/7ee938abbde2322e553a2cb5f604cdd1e4728e08bba39c7ee6fae9af840b/mkdocstrings_python-2.0.2-py3-none-any.whl", hash = "sha256:31241c0f43d85a69306d704d5725786015510ea3f3c4bdfdb5a5731d83cdc2b0", size = 104900, upload-time = "2026-02-09T15:12:00.166Z" },
 ]
 
 [[package]]
@@ -862,15 +886,15 @@ wheels = [
 
 [[package]]
 name = "poethepoet"
-version = "0.40.0"
+version = "0.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pastel" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/9d/054c8435b03324ed9abd5d5ab8c45065b1f42c23952cd23f13a5921d8465/poethepoet-0.40.0.tar.gz", hash = "sha256:91835f00d03d6c4f0e146f80fa510e298ad865e7edd27fe4cb9c94fdc090791b", size = 81114, upload-time = "2026-01-05T19:09:13.116Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/b9/fa92286560f70eaa40d473ea48376d20c6c21f63627d33c6bb1c5e385175/poethepoet-0.41.0.tar.gz", hash = "sha256:dcaad621dc061f6a90b17d091bebb9ca043d67bfe9bd6aa4185aea3ebf7ff3e6", size = 87780, upload-time = "2026-02-08T20:45:36.061Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/bc/73327d12b176abea7a3c6c7d760e1a953992f7b59d72c0354e39d7a353b5/poethepoet-0.40.0-py3-none-any.whl", hash = "sha256:afd276ae31d5c53573c0c14898118d4848ccee3709b6b0be6a1c6cbe522bbc8a", size = 106672, upload-time = "2026-01-05T19:09:11.536Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/5e/0b83e0222ce5921b3f9081eeca8c6fb3e1cfd5ca0d06338adf93b28ce061/poethepoet-0.41.0-py3-none-any.whl", hash = "sha256:4bab9fd8271664c5d21407e8f12827daeb6aa484dc6cc7620f0c3b4e62b42ee4", size = 113590, upload-time = "2026-02-08T20:45:34.697Z" },
 ]
 
 [[package]]
@@ -1318,7 +1342,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 ci = [
-    { name = "poethepoet", specifier = ">=0.32" },
+    { name = "poethepoet", specifier = ">=0.41" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-cov", specifier = ">=6" },
     { name = "pytest-mock", specifier = ">=3.15.1" },


### PR DESCRIPTION
- Bump poethepoet to >=0.41
- Add MD028 rule exemption for blockquote callouts
- Add check-template-update post-merge hook
- Add default_install_hook_types to prek.toml
- Upgrade uv.lock dependencies (griffe 2.0, coverage 7.13.4, etc.)

## Description

<!-- Brief description of what this PR does -->

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)
- [ ] `poe check` passes
- [ ] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-message-convention)

## Related Issues

<!-- Link related issues: Fixes #123, Related to #456 -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/surfmon/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
