### PR TITLE
refactor: split oversized functions to meet pylint complexity defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,13 +149,6 @@ select = [
     # Print statements (use logging instead)
     "T20",  # flake8-print
 ]
-ignore = [
-    # TODO(#22): Remove after refactoring oversized functions to meet pylint defaults
-    "PLR0912",  # too-many-branches (12 max)
-    "PLR0914",  # too-many-locals (15 max)
-    "PLR0915",  # too-many-statements (50 max)
-    "PLR1702",  # too-many-nested-blocks (5 max)
-]
 
 [tool.ruff.lint.per-file-ignores]
 "src/surfmon/cli.py" = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -613,7 +613,7 @@ class TestCleanupCommandEdgeCases:
 
         mock_paths = MagicMock()
         mock_paths.app_name = "Windsurf.app"
-        mocker.patch("surfmon.config.get_paths", return_value=mock_paths)
+        mocker.patch("surfmon.cli.get_paths", return_value=mock_paths)
 
         mock_proc = MagicMock()
         mock_proc.info = {
@@ -627,7 +627,7 @@ class TestCleanupCommandEdgeCases:
         mock_proc.memory_info.return_value.rss = 50 * 1024 * 1024
         mock_proc.kill.side_effect = psutil.AccessDenied(pid=5678)
 
-        mock_iter = mocker.patch("psutil.process_iter")
+        mock_iter = mocker.patch("surfmon.cli.psutil.process_iter")
         mock_iter.return_value = [mock_proc]
         result = runner.invoke(app, ["cleanup", "--force"])
         assert result.exit_code == 1


### PR DESCRIPTION
## Summary
Split oversized functions to meet pylint complexity defaults.

Closes #22

## Problem
After enabling pylint rules in PR #23, 30 complexity violations were detected (PLR0912 too many branches, PLR0915 too many statements, PLR0914 too many locals, PLR1702 too many nested blocks).

## Solution
Refactor all violations using these patterns:
- Extract helper functions to reduce branch/statement/local counts
- Use early returns and guard clauses to reduce nesting
- Extract repeated patterns (e.g., `_format_change` for Rich-styled diff indicators)
- Pass pre-computed values to helpers to avoid type-checking issues

All 30 violations fixed. Zero temporary ignores remain in pyproject.toml.

## Changes
- `src/surfmon/cli.py` — split `create_summary_table`, `watch`, `plot`, `report`, `_save_markdown`
- `src/surfmon/monitor.py` — split `collect_report`, `_collect_process_details`, `_collect_pty_info`, `_collect_log_info`
- `src/surfmon/output.py` — split `display_report`, `save_report_markdown`
- `src/surfmon/compare.py` — split comparison functions