### PR TITLE
fix: unify main-process detection logic between cli.py and monitor.py

### DIFF
--- a/src/surfmon/cli.py
+++ b/src/surfmon/cli.py
@@ -17,7 +17,7 @@ import typer
 from . import __version__
 from .compare import compare_reports
 from .config import WindsurfTarget, get_paths, get_target_display_name, set_target
-from .monitor import MonitoringReport, generate_report, save_report_json
+from .monitor import MonitoringReport, generate_report, is_main_windsurf_process, save_report_json
 from .output import (
     CPU_PERCENT_CRITICAL,
     CPU_PERCENT_WARNING,
@@ -987,11 +987,7 @@ def _find_orphaned_crashpad_procs(app_name: str) -> tuple[bool, list[tuple[psuti
             if app_name not in exe and app_name not in cmdline:
                 continue
 
-            if (
-                name.lower() == "windsurf"
-                or f"{app_name}/Contents/MacOS/Windsurf" in exe
-                or ("Windsurf" in name and "Helper" not in name and "crashpad" not in name.lower())
-            ):
+            if is_main_windsurf_process(name, exe, app_name):
                 main_windsurf_found = True
 
             if "crashpad" in name.lower():


### PR DESCRIPTION
## Summary
Extract shared `is_main_windsurf_process()` helper in monitor.py and use it in all 3 call sites to unify main-process detection logic.

Fixes #26

## Problem
The cli.py cleanup command had its own main-process detection logic that was missing Electron process checks present in monitor.py. This could cause the cleanup command to kill non-orphaned crashpad handlers.

## Solution
- Extract `is_main_windsurf_process()` helper in monitor.py with the complete detection logic (Electron + binary checks)
- Replace all 3 inline detection implementations with calls to the shared helper
- Ensures cli.py and monitor.py use identical logic

## Changes
- `src/surfmon/monitor.py` — new `is_main_windsurf_process()` helper function
- `src/surfmon/cli.py` — use shared helper instead of inline detection