### PR TITLE
refactor: consolidate duplicate PTY threshold constants

### DIFF
--- a/src/surfmon/cli.py
+++ b/src/surfmon/cli.py
@@ -15,14 +15,19 @@ import typer
 from . import __version__
 from .compare import compare_reports
 from .config import WindsurfTarget, get_paths, get_target_display_name, set_target
-from .monitor import MonitoringReport, generate_report, is_main_windsurf_process, save_report_json
+from .monitor import (
+    PTY_CRITICAL_COUNT,
+    PTY_USAGE_CRITICAL_PERCENT,
+    PTY_WARNING_COUNT,
+    MonitoringReport,
+    generate_report,
+    is_main_windsurf_process,
+    save_report_json,
+)
 from .output import (
     CPU_PERCENT_CRITICAL,
     CPU_PERCENT_WARNING,
     MB_PER_GB,
-    PTY_COUNT_CRITICAL,
-    PTY_COUNT_WARNING,
-    PTY_USAGE_PERCENT_CRITICAL,
     WINDSURF_MEM_PERCENT_CRITICAL,
     WINDSURF_MEM_PERCENT_WARNING,
     Live,
@@ -176,9 +181,9 @@ def _add_pty_row(table: Table, report: MonitoringReport, prev_report: Monitoring
     usage_pct = (pty.system_pty_used / pty.system_pty_limit) * 100 if pty.system_pty_limit > 0 else 0
     pty_color = (
         "red"
-        if pty.windsurf_pty_count >= PTY_COUNT_CRITICAL or usage_pct >= PTY_USAGE_PERCENT_CRITICAL
+        if pty.windsurf_pty_count >= PTY_CRITICAL_COUNT or usage_pct >= PTY_USAGE_CRITICAL_PERCENT
         else "yellow"
-        if pty.windsurf_pty_count >= PTY_COUNT_WARNING
+        if pty.windsurf_pty_count >= PTY_WARNING_COUNT
         else "green"
     )
     table.add_row(

--- a/src/surfmon/output.py
+++ b/src/surfmon/output.py
@@ -30,6 +30,7 @@ __all__ = [
 ]
 
 from .config import get_paths, get_target_display_name
+from .monitor import PTY_CRITICAL_COUNT, PTY_USAGE_CRITICAL_PERCENT, PTY_WARNING_COUNT
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -48,9 +49,6 @@ WINDSURF_MEM_PERCENT_CRITICAL = 20
 WINDSURF_MEM_PERCENT_WARNING = 10
 CPU_PERCENT_CRITICAL = 50
 CPU_PERCENT_WARNING = 20
-PTY_COUNT_CRITICAL = 200
-PTY_COUNT_WARNING = 50
-PTY_USAGE_PERCENT_CRITICAL = 80
 PROCESS_MEMORY_HIGH_MB = 1000
 PROCESS_MEMORY_MEDIUM_MB = 500
 LS_MEMORY_HIGH_MB = 1000
@@ -154,9 +152,9 @@ def _display_windsurf_table(report: MonitoringReport) -> None:
         usage_pct = (pty.system_pty_used / pty.system_pty_limit) * 100 if pty.system_pty_limit > 0 else 0
         pty_color = (
             "red"
-            if pty.windsurf_pty_count >= PTY_COUNT_CRITICAL or usage_pct >= PTY_USAGE_PERCENT_CRITICAL
+            if pty.windsurf_pty_count >= PTY_CRITICAL_COUNT or usage_pct >= PTY_USAGE_CRITICAL_PERCENT
             else "yellow"
-            if pty.windsurf_pty_count >= PTY_COUNT_WARNING
+            if pty.windsurf_pty_count >= PTY_WARNING_COUNT
             else "green"
         )
         ws_table.add_row(


### PR DESCRIPTION
## Summary
Remove duplicate PTY threshold constants from output.py and consolidate on the canonical constants in monitor.py.

Fixes #25

## Problem
output.py defined its own `PTY_COUNT_CRITICAL`, `PTY_COUNT_WARNING`, and `PTY_USAGE_PERCENT_CRITICAL` constants that duplicated the canonical values in monitor.py. This created a maintenance risk where thresholds could drift out of sync.

## Solution
- Remove duplicate constants from output.py
- Import `PTY_CRITICAL_COUNT`, `PTY_WARNING_COUNT`, `PTY_USAGE_CRITICAL_PERCENT` from monitor.py in both output.py and cli.py
- Single source of truth for all PTY thresholds

## Changes
- `src/surfmon/output.py` — remove duplicate constants, import from monitor
- `src/surfmon/cli.py` — import canonical constants from monitor