### PR TITLE
fix: add self-updating coverage badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,9 +159,22 @@ jobs:
     - name: Run the test suite
       run: uv run poe test-cov
 
-    - name: Upload coverage to Codecov
+    - name: Extract coverage percentage
       if: ${{ matrix.os == 'blacksmith-4vcpu-ubuntu-2404' && matrix.resolution == 'highest' }}
-      uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+      id: coverage
+      run: |
+        total=$(uv run coverage report --format=total)
+        echo "total=$total" >> "$GITHUB_OUTPUT"
+
+    - name: Update coverage badge
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.os == 'blacksmith-4vcpu-ubuntu-2404' && matrix.resolution == 'highest' }}
+      uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        fail_ci_if_error: false
+        auth: ${{ secrets.GIST_TOKEN }}
+        gistID: 759ab8d29e8650758515a72c9d8262d2
+        filename: coverage.json
+        label: coverage
+        message: ${{ steps.coverage.outputs.total }}%
+        valColorRange: ${{ steps.coverage.outputs.total }}
+        minColorRange: 50
+        maxColorRange: 90

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![documentation](https://img.shields.io/badge/docs-mkdocs-708FCC.svg?style=flat)](https://detailobsessed.github.io/surfmon/)
 [![pypi version](https://img.shields.io/pypi/v/surfmon.svg)](https://pypi.org/project/surfmon/)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14+-blue.svg)](https://www.python.org/downloads/)
-[![codecov](https://codecov.io/gh/detailobsessed/surfmon/branch/main/graph/badge.svg)](https://codecov.io/gh/detailobsessed/surfmon)
+[![coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/ichoosetoaccept/759ab8d29e8650758515a72c9d8262d2/raw/coverage.json)](https://github.com/detailobsessed/surfmon/actions?query=workflow%3Aci)
 
 **Surf**ace **Mon**itor for Windsurf IDE — a performance monitoring and diagnostics tool for [Windsurf](https://codeium.com/windsurf) (Stable and Next).
 


### PR DESCRIPTION
## Description

Add a self-updating test coverage badge to the README, replacing the Codecov badge.

**How it works:**
- CI extracts coverage percentage via `coverage report --format=total` after tests
- `schneegans/dynamic-badges-action` updates a [GitHub Gist](https://gist.github.com/ichoosetoaccept/759ab8d29e8650758515a72c9d8262d2) with the coverage data
- README references the gist via a shields.io endpoint badge
- Badge only updates on push to `main` (not on PRs)

**Setup required:**
- `GIST_TOKEN` repo secret (classic PAT with `gist` scope) ✅

## Checklist

- [ ] Tests added/updated
- [x] Documentation updated (if applicable)
- [x] `poe check` passes
- [x] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-message-convention)

## Related Issues

N/A — improvement to CI observability