### PR TITLE
feat: Windsurf Insiders support, require --target flag, improve plots

### DIFF
--- a/src/surfmon/monitor.py
+++ b/src/surfmon/monitor.py
@@ -760,7 +760,7 @@ def generate_report() -> MonitoringReport:
             log_issues.append(
                 f"🔴 CRITICAL: Windsurf processes are holding {pty_info.windsurf_pty_count} PTYs "
                 f"(system: {pty_info.system_pty_used}/{pty_info.system_pty_limit}, {usage_pct:.0f}% used) "
-                f"- Fix: Restart Windsurf to release leaked PTYs"
+                f"- Fix: Restart all Windsurf instances to release leaked PTYs"
             )
         elif pty_info.windsurf_pty_count >= PTY_WARNING_COUNT:
             log_issues.append(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,16 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from surfmon.config import WindsurfTarget, reset_target, set_target
+
+
+@pytest.fixture(autouse=True)
+def _default_target():
+    """Set a default target for all tests so code calling get_target() doesn't fail."""
+    set_target(WindsurfTarget.STABLE)
+    yield
+    reset_target()
+
 
 @pytest.fixture
 def mock_monitoring_report():


### PR DESCRIPTION
## Summary

Adds Windsurf Insiders build support, makes `--target` mandatory for live commands, and improves the analysis plot workflow. Closes #41, #40, #39.

## Changes

### Windsurf Insiders support
- Add `WindsurfTarget.INSIDERS` with paths for `~/.codeium/windsurf-insiders/`, `~/.windsurf-insiders/`, `Windsurf - Insiders.app`
- Skip orphaned crashpad handlers in `_detect_running_target()` so lingering Next crashpad processes don't override Insiders detection

### Require explicit `--target` flag
- `get_target()` now raises `TargetNotSetError` instead of silently auto-detecting or defaulting to STABLE
- `check`, `watch`, `cleanup` commands call `_require_target()` at entry — exits with a clear error message if neither `--target` nor `SURFMON_TARGET` env var is set
- `compare`, `prune`, `analyze` are unaffected (they operate on saved JSON files)
- Prevents cross-target confusion (e.g. `check -t next` finding an issue, then `cleanup` silently targeting Insiders)

### Plot improvements
- **#41**: Replace blocking `plt.show()` with interactive file save prompt; `--output` flag skips prompt; path expansion and overwrite confirmation included
- **#40**: Remove swap memory panel from 3×3 analysis grid
- **#39**: Add PTY usage panel with dual-axis (Windsurf PTY count + system PTY %), warning/critical threshold lines, system limit in title
- Extract `_plot_pty_chart()` helper from `_plot_row2_charts()` to stay within ruff statement/variable limits
- Load `pty_info` from saved JSON reports in `_load_reports()` for historical analysis

### Tests
- Insiders detection, crashpad filtering, required target enforcement, `--target insiders` acceptance
- Global `_default_target` fixture in `conftest.py` so all tests have a valid target set

## Closes

- Closes #41
- Closes #40
- Closes #39