### PR TITLE
feat: show elapsed session time in watch dashboard

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,14 +1,16 @@
 # Changes here will be overwritten by Copier.
-_commit: 0.27.11
+_commit: 0.29.2
 _src_path: gh:detailobsessed/copier-uv-bleeding
 author_email: ismar@gmail.com
 author_fullname: Ismar Iljazovic
 author_username: ichoosetoaccept
+cli_framework: typer
 copyright_license: MIT
+custom_pypi_index_url: ''
 project_description: Monitor Windsurf and Windsurf Next resource usage and diagnose
     problems
 project_name: surfmon
-project_type: package
+project_type: app
 project_visibility: public
 publish_to_pypi: true
 repository_host: github.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
         enable-cache: true
         cache-dependency-glob: pyproject.toml
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install dependencies
       run: uv run poe setup
@@ -143,6 +144,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
         enable-cache: true
         cache-dependency-glob: pyproject.toml
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         cache-suffix: ${{ matrix.resolution }}
 
     - name: Install dependencies
@@ -178,3 +180,14 @@ jobs:
         valColorRange: ${{ steps.coverage.outputs.total }}
         minColorRange: 50
         maxColorRange: 90
+
+  ci-pass:
+    if: always()
+    needs: [links, quality, tests]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check all jobs passed
+      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+      with:
+        allowed-skips: quality, tests
+        jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
       with:
         python-version: "3.14"
         enable-cache: true
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install dependencies
       run: uv sync --only-group maintain
@@ -84,6 +85,7 @@ jobs:
       uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
       with:
         python-version: "3.14"
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and publish
       run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Contributions are welcome, and they are greatly appreciated! Every little bit helps, and credit will always be given.
+Contributions are welcome! Every little bit helps, and credit will always be given.
 
 ## Requirements
 
@@ -9,8 +9,6 @@ Contributions are welcome, and they are greatly appreciated! Every little bit he
 - [prek](https://github.com/j178/prek) (pre-commit hook runner) — installed automatically by uv
 - Windsurf IDE installed (needed to run surfmon)
 
-## Environment setup
-
 Fork and clone the repository, then:
 
 ```bash
@@ -18,118 +16,39 @@ cd surfmon
 uv sync
 ```
 
-> NOTE: If it fails for some reason, you'll need to install [uv](https://github.com/astral-sh/uv) manually.
->
-> You can install it with:
->
-> ```bash
-> curl -LsSf https://astral.sh/uv/install.sh | sh
-> ```
->
-> Now you can try running `uv sync` again.
+This installs all dependencies including dev tools. If `uv` is not installed, see the [uv installation guide](https://docs.astral.sh/uv/getting-started/installation/).
 
-You now have the dependencies installed.
-
-You can run the application with `uv run surfmon [ARGS...]`.
-
-Run `poe` to see all the available tasks.
+Run the CLI with `uv run surfmon [ARGS...]`.
 
 ## Tasks
 
-The project uses [poe the poet](https://github.com/nat-n/poethepoet) as a task runner. Tasks are defined in `pyproject.toml` under the `[tool.poe.tasks]` section. Run `poe` to list all available tasks.
+This project uses [poethepoet](https://github.com/nat-n/poethepoet) as a task runner. Run `poe` to list all available tasks. Key tasks:
 
-Key tasks:
-
-- `poe lint` — run ruff linter
-- `poe format` — auto-format with ruff
-- `poe typecheck` — run ty type checker
-- `poe check` — run lint + typecheck in parallel
-- `poe test` — run tests (excludes slow tests)
-- `poe test-all` — run all tests including slow
+- `poe check` — lint + type check (parallel)
 - `poe fix` — auto-fix lint issues and format
+- `poe test` — run tests (excluding slow)
+- `poe test-all` — run all tests including slow
+
 - `poe docs` — serve documentation locally
 
 ## Development
 
-As usual:
+1. Create a branch: `git switch -c feature-or-bugfix-name`
+2. Make your changes
+3. Commit — git hooks automatically run formatting, linting, and tests
 
-1. create a new branch: `git switch -c feature-or-bugfix-name`
-1. edit the code and/or the documentation
+Don't worry about the changelog — it is generated automatically from commit messages.
 
-**Before committing:**
+## Commit messages
 
-1. run `poe format` to auto-format the code
-1. run `poe check` to run all quality checks (fix any warnings)
-1. run `poe test` to run the tests (fix any issues)
-1. if you updated the documentation or the project dependencies:
-    1. run `poe docs`
-    1. go to <http://localhost:8000> and check that everything looks good
-1. follow our [commit message convention](#commit-message-convention)
-
-If you are unsure about how to fix or ignore a warning, just let the continuous integration fail, and we will help you during review.
-
-Don't bother updating the changelog, we will take care of this.
-
-## Commit message convention
-
-Commit messages must follow our convention based on the [Angular style](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message) or the [Karma convention](https://karma-runner.github.io/4.0/dev/git-commit-msg.html):
+This project uses [Conventional Commits](https://www.conventionalcommits.org/). A git hook enforces the format, so you'll get immediate feedback if the message doesn't match:
 
 ```
 <type>[(scope)]: Subject
-
-[Body]
 ```
 
-**Subject and body must be valid Markdown.** Subject must have proper casing (uppercase for first letter if it makes sense), but no dot at the end, and no punctuation in general.
+Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `ci`, `chore`, `perf`.
 
-Scope and body are optional. Type can be:
+## Pull requests
 
-- `build`: About packaging, building wheels, etc.
-- `chore`: About packaging or repo/files management.
-- `ci`: About Continuous Integration.
-- `deps`: Dependencies update.
-- `docs`: About documentation.
-- `feat`: New feature.
-- `fix`: Bug fix.
-- `perf`: About performance.
-- `refactor`: Changes that are not features or bug fixes.
-- `style`: A change in code style/format.
-- `test`: About tests.
-
-If you write a body, please add trailers at the end (for example issues and PR references, or co-authors), without relying on GitHub's flavored Markdown:
-
-```
-Body.
-
-Issue #10: https://github.com/detailobsessed/surfmon/issues/10
-Related to PR detailobsessed/surfmon#15: https://github.com/detailobsessed/surfmon/pull/15
-```
-
-These "trailers" must appear at the end of the body, without any blank lines between them. The trailer title can contain any character except colons `:`. We expect a full URI for each trailer, not just GitHub autolinks (for example, full GitHub URLs for commits and issues, not the hash or the #issue-number).
-
-We do not enforce a line length on commit messages summary and body, but please avoid very long summaries, and very long lines in the body, unless they are part of code blocks that must not be wrapped.
-
-## Pull requests guidelines
-
-Link to any related issue in the Pull Request message.
-
-During the review, we recommend using fixups:
-
-```bash
-# SHA is the SHA of the commit you want to fix
-git commit --fixup=SHA
-```
-
-Once all the changes are approved, you can squash your commits:
-
-```bash
-git rebase -i --autosquash main
-```
-
-And force-push:
-
-```bash
-git push -f
-```
-
-If this seems all too complicated, you can push or force-push each new commit, and we will squash them ourselves if needed, before merging.
+Link to any related issue in the PR description. Keep commits focused — one logical change per commit. We squash-merge PRs, so don't worry about a clean commit history within the PR.

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ The `--target` flag is required for `check`, `watch`, and `cleanup`. Commands th
 
 | Issue | Cause | Fix |
 | ----- | ----- | --- |
-| Orphaned crash handlers | Crash reporters not cleaned up on exit | `surfmon cleanup --force` |
+| Orphaned crash handlers | Crash reporters not cleaned up on exit | `surfmon cleanup -t stable --force` |
 | `logs` directory error | Marimo extension creates logs in wrong place | Move `~/.windsurf/extensions/logs` |
 | Update service timeouts | DNS or firewall blocking update checks | Check DNS/firewall settings |
 | High memory usage | Too many language servers or extensions | Disable unused extensions |

--- a/prek.toml
+++ b/prek.toml
@@ -111,20 +111,22 @@ priority = 1
 [[repos.hooks]]
 id = "pytest-testmon"
 name = "pytest affected tests"
-entry = "uv run pytest --testmon --no-cov"
+entry = "uv run pytest -q --testmon --no-cov"
 language = "system"
 types = ["python"]
 pass_filenames = false
+verbose = true
 stages = ["pre-commit"]
 priority = 1
 
 [[repos.hooks]]
 id = "pytest-cov"
 name = "pytest with coverage"
-entry = "uv run pytest --cov --cov-fail-under=90 --cov-report=term-missing:skip-covered"
+entry = "uv run pytest -q --cov --cov-fail-under=90 --cov-report=term-missing:skip-covered"
 language = "system"
 types = ["python"]
 pass_filenames = false
+verbose = true
 stages = ["pre-push"]
 priority = 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "typer>=0.21",
+    "typer>=0.23",
     "psutil>=7.2",
     "rich>=14.3",
     "python-decouple>=3.8",
@@ -87,67 +87,71 @@ preview = true
 
 [tool.ruff.lint]
 select = [
-    # Core (ruff defaults)
+    # Core — universal baseline (ruff defaults + pycodestyle warnings)
     "E",    # pycodestyle errors
     "W",    # pycodestyle warnings
     "F",    # Pyflakes
 
-    # Modern Python
-    "UP",   # pyupgrade - use modern Python syntax
-    "I",    # isort - import sorting
+    # Modern Python — enforce current idioms
+    "UP",   # pyupgrade — use modern syntax (match, type unions, etc.)
+    "I",    # isort — deterministic import ordering
+    "FA",   # flake8-future-annotations — `from __future__ import annotations`
 
-    # Code quality
-    "A",    # flake8-builtins - prevent shadowing builtins (id, type, list, etc.)
-    "B",    # flake8-bugbear - common bugs and design issues
-    "SIM",  # flake8-simplify - simplify code
-    "C4",   # flake8-comprehensions - better comprehensions
-    "PIE",  # flake8-pie - misc improvements
-    "RET",  # flake8-return - return statement issues
-    "RSE",  # flake8-raise - raise best practices
+    # Code quality — catch bugs and enforce clean patterns
+    "A",    # flake8-builtins — prevent shadowing builtins (id, type, list)
+    "B",    # flake8-bugbear — common bugs and design issues
+    "SIM",  # flake8-simplify — simplifiable constructs
+    "C4",   # flake8-comprehensions — better comprehensions
+    "PIE",  # flake8-pie — misc quality improvements
+    "RET",  # flake8-return — consistent return statements
+    "RSE",  # flake8-raise — raise best practices
+    "ISC",  # flake8-implicit-str-concat — catch missing commas in collections
     "RUF",  # Ruff-specific rules
-    "FA",   # flake8-future-annotations
-    "ISC",  # flake8-implicit-str-concat - catch missing commas
-    "ICN",  # flake8-import-conventions
-    "TID",  # flake8-tidy-imports - absolute imports
-    "TC",   # flake8-type-checking - TYPE_CHECKING imports
-    "PTH",  # flake8-use-pathlib - prefer pathlib over os.path
-    "FURB", # refurb - modernize and simplify code
-    "FLY",  # flynt - prefer f-strings over .format() and %
+    "FURB", # refurb — modernise and simplify code
+    "FLY",  # flynt — prefer f-strings over .format() and %
+    "PGH",  # pygrep-hooks — catch bare `# type: ignore`, eval(), etc.
 
-    # Naming
-    # "N",  # pep8-naming - PEP 8 naming conventions (enable when ready)
+    # Import hygiene
+    "ICN",  # flake8-import-conventions — enforce standard aliases (np, pd)
+    "TID",  # flake8-tidy-imports — ban relative imports, enforce absolute
+    "TC",   # flake8-type-checking — move imports behind TYPE_CHECKING
 
-    # Datetime
-    "DTZ",  # flake8-datetimez - enforce timezone-aware datetimes
+    # Naming — currently disabled; enable once existing code conforms
+    # "N",  # pep8-naming — PEP 8 naming conventions
+
+    # Correctness
+    "DTZ",  # flake8-datetimez — enforce timezone-aware datetimes
+    "PTH",  # flake8-use-pathlib — prefer pathlib over os.path
 
     # Error messages
-    "EM",   # flake8-errmsg - no string literals in exceptions
+    "EM",   # flake8-errmsg — variables in exception constructors (better tracebacks)
 
-    # Pylint
+    # Pylint — uses default thresholds; do not inflate to hide violations
     "PLC",  # pylint conventions
     "PLE",  # pylint errors
     "PLR",  # pylint refactor (too-many-args, too-many-branches, etc.)
     "PLW",  # pylint warnings
 
     # Performance
-    "PERF", # Perflint - performance anti-patterns
+    "PERF", # Perflint — performance anti-patterns
 
     # Security
-    "S",    # flake8-bandit - security issues
+    "S",    # flake8-bandit — security issues
 
     # Testing
-    "PT",   # flake8-pytest-style
+    "PT",   # flake8-pytest-style — consistent pytest idioms
 
     # Error handling
-    "TRY",  # tryceratops - exception handling
-    "LOG",  # flake8-logging - logging best practices
+    "TRY",  # tryceratops — exception handling best practices
+    "LOG",  # flake8-logging — logging best practices
 
-    # Unused code
+    # Housekeeping
     "ARG",  # flake8-unused-arguments
-    "ERA",  # eradicate - commented-out code
-
-    # Print statements (use logging instead)
-    "T20",  # flake8-print
+    "ERA",  # eradicate — commented-out code
+    "T20",  # flake8-print — use logging instead of print()
+]
+ignore = [
+    "TRY003",  # Overly strict — forces custom exception classes for every error message
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -161,7 +165,7 @@ select = [
     "T201",       # Hooks may print diagnostics
 ]
 "tests/**" = [
-    "S101", "S603", "S607", "S701",  # Allow assert, subprocess, jinja2 in tests
+    "S101", "S404", "S603", "S607",  # Allow assert and subprocess in tests
     "T201",       # Allow print in tests
     "PLR6301",    # Test methods don't use self (pytest classes)
     "PLR2004",    # Magic values in assertions are fine
@@ -204,7 +208,7 @@ source = ["src/"]
 
 [tool.coverage.report]
 precision = 2
-omit = ["src/*/__init__.py", "tests/__init__.py"]
+omit = ["src/*/__init__.py"]
 exclude_lines = ["pragma: no cover", "if TYPE_CHECKING", "if __name__ == .__main__.:"]
 
 [tool.coverage.json]
@@ -245,7 +249,7 @@ prek = "prek run --all-files"
 
 # Template utilities
 check-template = "bash scripts/check-template-update.sh"
-update-template = { shell = "copier update --trust . --skip-answered && uv sync --upgrade && prek autoupdate && echo '  ✓ Dependencies upgraded and hook versions updated'" }
+update-template = { shell = "copier update --trust . --skip-answered --defaults && uv sync --upgrade && prek autoupdate && echo '  ✓ Dependencies upgraded and hook versions updated'" }
 
 # Git utilities
 tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"

--- a/scripts/check-template-update.sh
+++ b/scripts/check-template-update.sh
@@ -47,9 +47,13 @@ touch "$cache_file"
 
 if [[ "$local_version" != "$latest" ]]; then
   cyan='\033[0;36m'; yellow='\033[1;33m'; dim='\033[2m'; bold='\033[1m'; reset='\033[0m'
-  echo ""
-  echo -e "  ${cyan}ℹ️  Template update available:${reset} ${dim}${local_version}${reset} ${bold}→${reset} ${yellow}${latest}${reset}"
-  echo -e "  ${dim}Run:${reset} copier update --trust . --skip-answered"
-  echo -e "  ${dim}Or:${reset}  poe update-template"
-  echo ""
+  # Write to /dev/tty to bypass output capture by hook runners (prek, gt).
+  # Falls back to stdout for non-interactive contexts (CI, scripts, tests).
+  out="/dev/stdout"
+  if (echo -n > /dev/tty) 2>/dev/null; then out="/dev/tty"; fi
+  echo "" > "$out"
+  echo -e "  ${cyan}ℹ️  Template update available:${reset} ${dim}${local_version}${reset} ${bold}→${reset} ${yellow}${latest}${reset}" > "$out"
+  echo -e "  ${dim}Run:${reset} copier update --trust . --skip-answered" > "$out"
+  echo -e "  ${dim}Or:${reset}  poe update-template" > "$out"
+  echo "" > "$out"
 fi

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -599,6 +599,51 @@ class TestCreateSummaryTable:
         assert table is not None
 
 
+class TestFormatElapsed:
+    """Tests for _format_elapsed helper."""
+
+    @pytest.mark.parametrize(
+        ("seconds", "expected"),
+        [
+            (0, "0:00"),
+            (59, "0:59"),
+            (60, "1:00"),
+            (90, "1:30"),
+            (3599, "59:59"),
+            (3600, "1:00:00"),
+            (3661, "1:01:01"),
+            (86399, "23:59:59"),
+        ],
+    )
+    def test_format_elapsed(self, seconds, expected):
+        """Should format seconds as M:SS or H:MM:SS."""
+        from surfmon.cli import _format_elapsed
+
+        assert _format_elapsed(seconds) == expected
+
+
+class TestCreateSummaryTableSessionStart:
+    """Tests for session_start parameter on create_summary_table."""
+
+    def test_no_elapsed_without_session_start(self, mock_generate_report):
+        """Should not show elapsed time when session_start is None."""
+        from surfmon.cli import create_summary_table
+
+        report = mock_generate_report.return_value
+        table = create_summary_table(report)
+        assert "elapsed" not in (table.title or "")
+
+    def test_shows_elapsed_with_session_start(self, mock_generate_report):
+        """Should show elapsed time when session_start is provided."""
+        import time
+
+        from surfmon.cli import create_summary_table
+
+        report = mock_generate_report.return_value
+        table = create_summary_table(report, session_start=time.time() - 3661)
+        assert "elapsed 1:01:0" in (table.title or "")
+
+
 class TestCreateSummaryTableChanges:
     """Tests for create_summary_table with prev_report showing actual changes."""
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -902,7 +902,7 @@ class TestCheckPtyLeak:
 
     def test_handles_timeout(self, mocker):
         """Should handle subprocess timeout gracefully."""
-        import subprocess  # noqa: S404
+        import subprocess
 
         mock_run = mocker.patch("surfmon.monitor.subprocess.run")
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="lsof", timeout=10)

--- a/uv.lock
+++ b/uv.lock
@@ -1375,7 +1375,7 @@ requires-dist = [
     { name = "psutil", specifier = ">=7.2" },
     { name = "python-decouple", specifier = ">=3.8" },
     { name = "rich", specifier = ">=14.3" },
-    { name = "typer", specifier = ">=0.21" },
+    { name = "typer", specifier = ">=0.23" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

Adds elapsed session time to the watch dashboard title so users can see at a glance how long monitoring has been running.

## Changes

- **`_format_elapsed()`**: New helper that formats seconds as `H:MM:SS` (for sessions ≥1h) or `M:SS` (shorter)
- **`create_summary_table()`**: New `session_start` parameter; when provided, appends elapsed time to the title
- **`_print_watch_banner()`**: Extracted from `watch()` to keep it under the ruff statement limit (PLR0915)

### Before
```
Windsurf Monitor - 16:12:01
```

### After
```
Windsurf Monitor - 16:12:01 (elapsed 1:23:45)
```