### PR TITLE
fix: DRY up snapshot command internals (ISM-331)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,4 @@
-## Description
+Closes ISM-XXX
 
-<!-- Brief description of what this PR does -->
-
-## Checklist
-
-- [ ] Tests added/updated
-- [ ] Documentation updated (if applicable)
-- [ ] `poe check` passes
-- [ ] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-messages)
-
-## Related Issues
-
-<!-- Link related issues: Fixes #123, Related to #456 -->
+<!-- Replace ISM-XXX with the Linear issue this PR closes (auto-transitions to Done on merge).
+     Use "Ref ISM-XXX" to link without closing. Delete the line for chore PRs with no issue. -->

--- a/src/surfmon/cli.py
+++ b/src/surfmon/cli.py
@@ -28,9 +28,8 @@ from .monitor import (
     _get_windsurf_uptime,
     capture_ls_snapshot,
     check_pty_leak,
+    collect_process_infos,
     generate_report,
-    get_process_info,
-    get_windsurf_processes,
     is_main_windsurf_process,
     save_report_json,
 )
@@ -353,33 +352,12 @@ def check(
         # Handle --save flag (auto-generate filenames under ~/.surfmon/reports/)
         if save:
             save_dir = DEFAULT_REPORTS_DIR
-            try:
-                save_dir.mkdir(parents=True, exist_ok=True)
-            except OSError as e:
-                console.print(f"[red]Error: Cannot create reports directory: {save_dir}[/red]")
-                console.print(f"[red]  {e}[/red]")
-                raise typer.Exit(code=1) from e
+            _ensure_reports_dir(save_dir)
             timestamp = datetime.now(tz=UTC).strftime("%Y%m%d-%H%M%S")
             json_file = save_dir / f"surfmon-{timestamp}.json"
             markdown_path = save_dir / f"surfmon-{timestamp}.md"
 
-        # Show saved file paths
-        if json_file or markdown_path:
-            console.print()
-            if json_file:
-                json_file = json_file.resolve()
-                try:
-                    save_report_json(report, json_file)
-                    console.print(f"[green]✓ JSON report saved to {json_file}[/green]")
-                except OSError as e:
-                    console.print(f"[red]Error: Cannot save JSON report to {json_file}: {e}[/red]")
-            if markdown_path:
-                markdown_path = markdown_path.resolve()
-                try:
-                    save_report_markdown(report, markdown_path)
-                    console.print(f"[green]✓ Markdown report saved to {markdown_path}[/green]")
-                except OSError as e:
-                    console.print(f"[red]Error: Cannot save Markdown report to {markdown_path}: {e}[/red]")
+        _save_snapshot_files(json_file, markdown_path, save_report_json, save_report_markdown, report)
 
         # Exit with non-zero if critical issues detected
         if report.log_issues:
@@ -764,8 +742,7 @@ def pty_snapshot(
         target_name = get_target_display_name()
         with console.status(f"[cyan]Capturing PTY snapshot for {target_name}...[/cyan]", spinner="dots"):
             # Gather Windsurf processes for version/uptime
-            procs = get_windsurf_processes()
-            proc_infos = [pi for p in procs if (pi := get_process_info(p))]
+            proc_infos = collect_process_infos()
             pty = check_pty_leak(windsurf_processes=proc_infos)
 
         # --json: output JSON to stdout and skip rich display
@@ -779,27 +756,12 @@ def pty_snapshot(
         # Handle --save flag
         if save:
             save_dir = DEFAULT_REPORTS_DIR
-            save_dir.mkdir(parents=True, exist_ok=True)
+            _ensure_reports_dir(save_dir)
             timestamp = datetime.now(tz=UTC).strftime("%Y%m%d-%H%M%S")
             json_file = save_dir / f"pty-snapshot-{timestamp}.json"
             markdown_path = save_dir / f"pty-snapshot-{timestamp}.md"
 
-        if json_file or markdown_path:
-            console.print()
-            if json_file:
-                json_file = json_file.resolve()
-                try:
-                    _save_pty_snapshot_json(pty, json_file)
-                    console.print(f"[green]✓ JSON snapshot saved to {json_file}[/green]")
-                except OSError as e:
-                    console.print(f"[red]Error: Cannot save JSON: {e}[/red]")
-            if markdown_path:
-                markdown_path = markdown_path.resolve()
-                try:
-                    _save_pty_snapshot_markdown(pty, markdown_path)
-                    console.print(f"[green]✓ Markdown snapshot saved to {markdown_path}[/green]")
-                except OSError as e:
-                    console.print(f"[red]Error: Cannot save Markdown: {e}[/red]")
+        _save_snapshot_files(json_file, markdown_path, _save_pty_snapshot_json, _save_pty_snapshot_markdown, pty)
 
     except KeyboardInterrupt:
         console.print("\n[yellow]Interrupted by user[/yellow]")
@@ -939,35 +901,14 @@ def _save_snapshot_files(json_file, markdown_path, save_json_fn, save_md_fn, dat
             console.print(f"[red]Error: Cannot save Markdown: {e}[/red]")
 
 
-def _collect_process_infos() -> list:
-    """Collect Windsurf process infos with CPU sampling."""
-    procs = get_windsurf_processes()
-
-    cpu_samples: dict[int, psutil.Process] = {}
-    for proc in procs:
-        try:
-            proc.cpu_percent()
-            cpu_samples[proc.pid] = proc
-        except psutil.NoSuchProcess, psutil.AccessDenied:
-            pass
-
-    if cpu_samples:
-        time.sleep(0.5)
-
-    cpu_values: dict[int, float] = {}
-    for pid, proc in cpu_samples.items():
-        try:
-            cpu_values[pid] = proc.cpu_percent()
-        except psutil.NoSuchProcess, psutil.AccessDenied:
-            cpu_values[pid] = 0.0
-
-    result = []
-    for p in procs:
-        cpu = cpu_values.get(p.pid, 0.0)
-        if pi := get_process_info(p, initial_cpu=cpu):
-            result.append(pi)
-
-    return result
+def _ensure_reports_dir(save_dir: Path) -> None:
+    """Create reports directory with error handling."""
+    try:
+        save_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        console.print(f"[red]Error: Cannot create reports directory: {save_dir}[/red]")
+        console.print(f"[red]  {e}[/red]")
+        raise typer.Exit(code=1) from e
 
 
 @app.command(name="ls-snapshot")
@@ -995,7 +936,7 @@ def ls_snapshot(
     try:
         target_name = get_target_display_name()
         with console.status(f"[cyan]Capturing language server snapshot for {target_name}...[/cyan]", spinner="dots"):
-            proc_infos = _collect_process_infos()
+            proc_infos = collect_process_infos()
             version = _extract_windsurf_version(proc_infos)
             uptime = _get_windsurf_uptime(proc_infos)
             snapshot = capture_ls_snapshot(proc_infos, version, uptime)
@@ -1008,7 +949,7 @@ def ls_snapshot(
 
         if save:
             save_dir = DEFAULT_REPORTS_DIR
-            save_dir.mkdir(parents=True, exist_ok=True)
+            _ensure_reports_dir(save_dir)
             timestamp = datetime.now(tz=UTC).strftime("%Y%m%d-%H%M%S")
             json_file = save_dir / f"ls-snapshot-{timestamp}.json"
             markdown_path = save_dir / f"ls-snapshot-{timestamp}.md"

--- a/src/surfmon/monitor.py
+++ b/src/surfmon/monitor.py
@@ -954,38 +954,44 @@ def count_windsurf_launches_today() -> int:
     return launches
 
 
-def generate_report() -> MonitoringReport:
-    """Generate complete monitoring report with optimized CPU sampling."""
-    # Get processes
+def collect_process_infos() -> list[ProcessInfo]:
+    """Collect Windsurf process infos with CPU sampling.
+
+    Initializes CPU counters, waits 500ms, then reads final values.
+    Shared by generate_report() and CLI snapshot commands.
+    """
     procs = get_windsurf_processes()
 
-    # Initialize CPU sampling (non-blocking)
-    cpu_samples = {}
+    cpu_samples: dict[int, psutil.Process] = {}
     for proc in procs:
         try:
-            proc.cpu_percent()  # First call initializes, returns 0.0
+            proc.cpu_percent()
             cpu_samples[proc.pid] = proc
         except psutil.NoSuchProcess, psutil.AccessDenied:
             pass
 
-    # Sleep once for all processes (instead of once per process)
     if cpu_samples:
-        time.sleep(0.5)  # 500ms is enough for reasonable CPU measurement
+        time.sleep(0.5)
 
-    # Get final CPU samples
-    cpu_values = {}
+    cpu_values: dict[int, float] = {}
     for pid, proc in cpu_samples.items():
         try:
             cpu_values[pid] = proc.cpu_percent()
         except psutil.NoSuchProcess, psutil.AccessDenied:
             cpu_values[pid] = 0.0
 
-    # Build process info with pre-sampled CPU
-    proc_infos = []
+    result = []
     for p in procs:
         cpu = cpu_values.get(p.pid, 0.0)
         if pi := get_process_info(p, initial_cpu=cpu):
-            proc_infos.append(pi)
+            result.append(pi)
+
+    return result
+
+
+def generate_report() -> MonitoringReport:
+    """Generate complete monitoring report with optimized CPU sampling."""
+    proc_infos = collect_process_infos()
 
     total_memory = sum(p.memory_mb for p in proc_infos)
     total_cpu = sum(p.cpu_percent for p in proc_infos)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,7 +97,7 @@ class TestCheckCommand:
 
         result = runner.invoke(app, ["check", "--save"])
 
-        assert "Cannot save JSON report" in result.stdout
+        assert "Cannot save JSON" in result.stdout
 
     def test_check_with_explicit_json_file(
         self,
@@ -327,7 +327,7 @@ class TestCheckSaveDirError:
 
         result = runner.invoke(app, ["check", "--save"])
 
-        assert "Cannot save Markdown report" in result.stdout
+        assert "Cannot save Markdown" in result.stdout
 
 
 class TestPruneCommand:
@@ -949,7 +949,7 @@ class TestPtySnapshotCommand:
             windsurf_uptime_seconds=7200.0,
             raw_lsof="COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\nWindsurf 1000 ismar 33u CHR 15,0 0t0 605 /dev/ptmx\n",
         )
-        mocker.patch("surfmon.cli.get_windsurf_processes", return_value=[])
+        mocker.patch("surfmon.cli.collect_process_infos", return_value=[])
         mocker.patch("surfmon.cli.check_pty_leak", return_value=mock_pty)
         return mock_pty
 
@@ -1085,7 +1085,7 @@ class TestLsSnapshotCommand:
             issues=[],
         )
 
-        mocker.patch("surfmon.cli._collect_process_infos", return_value=mock_proc_infos)
+        mocker.patch("surfmon.cli.collect_process_infos", return_value=mock_proc_infos)
         mocker.patch("surfmon.cli._extract_windsurf_version", return_value="2.5.0")
         mocker.patch("surfmon.cli._get_windsurf_uptime", return_value=3600.0)
         mocker.patch("surfmon.cli.capture_ls_snapshot", return_value=mock_snapshot)
@@ -1175,7 +1175,7 @@ class TestLsSnapshotDisplay:
             issues=["CRITICAL: language_server_macos_arm indexing non-existent workspace"],
         )
 
-        mocker.patch("surfmon.cli._collect_process_infos", return_value=[])
+        mocker.patch("surfmon.cli.collect_process_infos", return_value=[])
         mocker.patch("surfmon.cli._extract_windsurf_version", return_value="2.5.0")
         mocker.patch("surfmon.cli._get_windsurf_uptime", return_value=3600.0)
         mocker.patch("surfmon.cli.capture_ls_snapshot", return_value=snapshot)
@@ -1212,7 +1212,7 @@ class TestLsSnapshotDisplay:
             issues=[],
         )
 
-        mocker.patch("surfmon.cli._collect_process_infos", return_value=[])
+        mocker.patch("surfmon.cli.collect_process_infos", return_value=[])
         mocker.patch("surfmon.cli._extract_windsurf_version", return_value="")
         mocker.patch("surfmon.cli._get_windsurf_uptime", return_value=0.0)
         mocker.patch("surfmon.cli.capture_ls_snapshot", return_value=snapshot)


### PR DESCRIPTION
Closes ISM-331

Extract shared helpers to DRY up snapshot command internals:

- Move CPU sampling logic from `cli.py` into `collect_process_infos()` in `monitor.py`, shared by `generate_report()` and CLI snapshot commands
- Add `_ensure_reports_dir()` helper with proper error handling for `--save` directory creation
- Migrate `pty-snapshot` and `check` commands to use the shared `_save_snapshot_files()` helper (already used by `ls-snapshot`)
- Replace direct `get_windsurf_processes()`/`get_process_info()` calls in `pty-snapshot` with `collect_process_infos()`, adding accurate CPU sampling