### PR TITLE
fix: align uptime formatting between cli.py and output.py (ISM-301)

### DIFF
--- a/src/surfmon/cli.py
+++ b/src/surfmon/cli.py
@@ -29,6 +29,7 @@ from .monitor import (
     capture_ls_snapshot,
     check_pty_leak,
     collect_process_infos,
+    format_uptime,
     generate_report,
     is_main_windsurf_process,
     save_report_json,
@@ -549,20 +550,6 @@ def cleanup(
         raise typer.Exit(code=1)
 
 
-def _format_uptime(seconds: float) -> str:
-    """Format uptime seconds as a human-readable string."""
-    if seconds <= 0:
-        return "unknown"
-    total = int(seconds)
-    h, remainder = divmod(total, 3600)
-    m, s = divmod(remainder, 60)
-    if h > 0:
-        return f"{h}h {m}m {s}s"
-    if m > 0:
-        return f"{m}m {s}s"
-    return f"{s}s"
-
-
 def _display_pty_snapshot(pty: PtyInfo) -> None:
     """Display a comprehensive PTY forensic snapshot to the console."""
     # Summary table
@@ -581,7 +568,7 @@ def _display_pty_snapshot(pty: PtyInfo) -> None:
     if pty.windsurf_version:
         summary.add_row("Windsurf Version", pty.windsurf_version)
     if pty.windsurf_uptime_seconds > 0:
-        summary.add_row("Windsurf Uptime", _format_uptime(pty.windsurf_uptime_seconds))
+        summary.add_row("Windsurf Uptime", format_uptime(pty.windsurf_uptime_seconds))
     console.print(summary)
     console.print()
 
@@ -654,7 +641,7 @@ def _save_pty_snapshot_markdown(pty: PtyInfo, path: Path) -> None:
         "",
         f"**Timestamp:** {datetime.now(tz=UTC).isoformat()}",
         f"**Windsurf Version:** {pty.windsurf_version or 'unknown'}",
-        f"**Windsurf Uptime:** {_format_uptime(pty.windsurf_uptime_seconds)}",
+        f"**Windsurf Uptime:** {format_uptime(pty.windsurf_uptime_seconds)}",
         "",
         "## Summary",
         "",
@@ -785,7 +772,7 @@ def _display_ls_snapshot(snapshot: LsSnapshot) -> None:
     if snapshot.windsurf_version:
         summary.add_row("Windsurf Version", snapshot.windsurf_version)
     if snapshot.windsurf_uptime_seconds > 0:
-        summary.add_row("Windsurf Uptime", _format_uptime(snapshot.windsurf_uptime_seconds))
+        summary.add_row("Windsurf Uptime", format_uptime(snapshot.windsurf_uptime_seconds))
     console.print(summary)
     console.print()
 
@@ -802,7 +789,7 @@ def _display_ls_snapshot(snapshot: LsSnapshot) -> None:
         detail.add_column("Status")
 
         for entry in snapshot.entries:
-            runtime = _format_uptime(entry.runtime_seconds)
+            runtime = format_uptime(entry.runtime_seconds)
             status = "[red]ORPHANED[/red]" if entry.orphaned else "[green]ok[/green]"
             if entry.memory_mb > LS_PROC_MEM_CRITICAL_MB:
                 mem_style = "red"
@@ -845,7 +832,7 @@ def _save_ls_snapshot_markdown(snapshot: LsSnapshot, path: Path) -> None:
         "",
         f"**Timestamp:** {snapshot.timestamp}",
         f"**Windsurf Version:** {snapshot.windsurf_version or 'unknown'}",
-        f"**Windsurf Uptime:** {_format_uptime(snapshot.windsurf_uptime_seconds)}",
+        f"**Windsurf Uptime:** {format_uptime(snapshot.windsurf_uptime_seconds)}",
         "",
         "## Summary",
         "",
@@ -863,7 +850,7 @@ def _save_ls_snapshot_markdown(snapshot: LsSnapshot, path: Path) -> None:
             "|-----|----------|--------|-------|---------|---------|-----------|--------|",
         ])
         for entry in snapshot.entries:
-            runtime = _format_uptime(entry.runtime_seconds)
+            runtime = format_uptime(entry.runtime_seconds)
             status = "ORPHANED" if entry.orphaned else "ok"
             lines.append(
                 f"| {entry.pid} | {entry.language} | {entry.memory_mb:.1f} MB "

--- a/src/surfmon/monitor.py
+++ b/src/surfmon/monitor.py
@@ -674,6 +674,23 @@ def check_pty_leak(windsurf_processes: list[ProcessInfo] | None = None) -> PtyIn
     )
 
 
+def format_uptime(seconds: float) -> str:
+    """Format uptime seconds as a human-readable string.
+
+    Shared by CLI display, PTY snapshot, LS snapshot, and Markdown reports.
+    """
+    if seconds <= 0:
+        return "unknown"
+    total = int(seconds)
+    h, remainder = divmod(total, 3600)
+    m, s = divmod(remainder, 60)
+    if h > 0:
+        return f"{h}h {m}m {s}s"
+    if m > 0:
+        return f"{m}m {s}s"
+    return f"{s}s"
+
+
 def _format_age_str(days: float) -> str:
     """Format age in days to human-readable string."""
     if days >= 1:

--- a/src/surfmon/output.py
+++ b/src/surfmon/output.py
@@ -8,6 +8,8 @@ from rich.live import Live
 from rich.panel import Panel
 from rich.table import Table
 
+from surfmon.monitor import format_uptime
+
 __all__ = [
     "CPU_PERCENT_CRITICAL",
     "CPU_PERCENT_WARNING",
@@ -345,9 +347,7 @@ def _format_pty_markdown(pty: Any) -> list[str]:
     if pty.windsurf_version:
         lines.append(f"- **Windsurf Version:** {pty.windsurf_version}")
     if pty.windsurf_uptime_seconds > 0:
-        h = int(pty.windsurf_uptime_seconds) // 3600
-        m = (int(pty.windsurf_uptime_seconds) % 3600) // 60
-        lines.append(f"- **Windsurf Uptime:** {h}h {m}m")
+        lines.append(f"- **Windsurf Uptime:** {format_uptime(pty.windsurf_uptime_seconds)}")
     lines.append("")
 
     if pty.per_process:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1311,28 +1311,28 @@ class TestSaveSnapshotFiles:
 
 
 class TestFormatUptime:
-    """Tests for _format_uptime helper."""
+    """Tests for format_uptime helper."""
 
     def test_format_hours(self):
         """Should format hours, minutes, seconds."""
-        from surfmon.cli import _format_uptime
+        from surfmon.monitor import format_uptime
 
-        assert _format_uptime(3661.0) == "1h 1m 1s"
+        assert format_uptime(3661.0) == "1h 1m 1s"
 
     def test_format_minutes(self):
         """Should format minutes and seconds."""
-        from surfmon.cli import _format_uptime
+        from surfmon.monitor import format_uptime
 
-        assert _format_uptime(125.0) == "2m 5s"
+        assert format_uptime(125.0) == "2m 5s"
 
     def test_format_seconds(self):
         """Should format seconds only."""
-        from surfmon.cli import _format_uptime
+        from surfmon.monitor import format_uptime
 
-        assert _format_uptime(42.0) == "42s"
+        assert format_uptime(42.0) == "42s"
 
     def test_format_zero(self):
         """Should return unknown for zero."""
-        from surfmon.cli import _format_uptime
+        from surfmon.monitor import format_uptime
 
-        assert _format_uptime(0.0) == "unknown"
+        assert format_uptime(0.0) == "unknown"


### PR DESCRIPTION
Closes ISM-301

Extract `format_uptime()` into `monitor.py` as a shared utility and use it consistently:

- `cli.py` had `_format_uptime()` formatting as `1h 1m 1s` (hours, minutes, seconds)
- `output.py` used inline calculation formatting as `1h 1m` (hours, minutes only)
- Now both use the shared `format_uptime()` with full precision (h/m/s as needed)