### PR TITLE
fix: resolve false-positive orphan detection for hyphenated/dotted workspace paths

### DIFF
--- a/src/surfmon/monitor.py
+++ b/src/surfmon/monitor.py
@@ -276,9 +276,7 @@ def _enhance_language_server_cmdline(p: ProcessInfo) -> str | None:
     # Extract workspace ID for Codeium language server
     workspace_match = re.search(r"--workspace_id\s+(\S+)", cmdline)
     if workspace_match:
-        workspace = workspace_match.group(1).replace("file_", "").replace("_", "/")
-        parts = workspace.split("/")
-        workspace_short = "/".join(parts[-PATH_COMPONENTS_SHORT:]) if len(parts) > PATH_COMPONENTS_SHORT else workspace
+        workspace_short = _extract_workspace_from_cmdline(cmdline)
         enhanced = f"{p.name} [workspace: {workspace_short}]"
 
     # Extract language for JDT LS
@@ -351,11 +349,65 @@ def _detect_language(cmdline: str) -> str:
     return "Unknown"
 
 
+def _resolve_workspace_path(workspace_id: str) -> Path | None:
+    """Resolve a Codeium workspace_id to an existing filesystem path.
+
+    Codeium encodes ``/``, ``-``, and ``.`` as ``_`` in its ``--workspace_id``
+    argument.  A naïve ``replace("_", "/")`` produces false paths for any
+    directory whose name contains hyphens or dots (e.g. ``copier-uv-bleeding``
+    becomes ``copier/uv/bleeding``).
+
+    This function walks the filesystem, trying ``/``, ``-``, and ``.`` for each
+    encoded underscore until it finds a path that actually exists.  Returns
+    ``None`` when no valid decoding is found (truly orphaned workspace).
+    """
+    raw = workspace_id.removeprefix("file_")
+    segments = raw.split("_")
+
+    # Fast path: simple all-slashes decode
+    simple = Path("/" + "/".join(segments))
+    if simple.exists():
+        return simple
+
+    return _try_joiners(Path("/"), segments)
+
+
+def _try_joiners(base: Path, segments: list[str]) -> Path | None:
+    """Try ``/``, ``-``, and ``.`` for each underscore between *segments*."""
+    if len(segments) == 1:
+        candidate = base / segments[0]
+        return candidate if candidate.exists() else None
+
+    first, rest = segments[0], segments[1:]
+
+    # Option 1: underscore was / (new path component)
+    child = base / first
+    if child.is_dir():
+        result = _try_joiners(child, rest)
+        if result is not None:
+            return result
+
+    # Option 2/3: underscore was - or . (merge with next segment)
+    for joiner in ("-", "."):
+        merged = [first + joiner + rest[0], *rest[1:]]
+        result = _try_joiners(base, merged)
+        if result is not None:
+            return result
+
+    return None
+
+
 def _extract_workspace_from_cmdline(cmdline: str) -> str:
     """Extract workspace path from a language server command line."""
     workspace_match = re.search(r"--workspace_id\s+(\S+)", cmdline)
     if workspace_match:
-        workspace = workspace_match.group(1).replace("file_", "").replace("_", "/")
+        workspace_id = workspace_match.group(1)
+        resolved = _resolve_workspace_path(workspace_id)
+        if resolved is not None:
+            parts = resolved.parts
+            return "/".join(parts[-PATH_COMPONENTS_SHORT:]) if len(parts) > PATH_COMPONENTS_SHORT else str(resolved)
+        # Fallback: naïve decode for display
+        workspace = workspace_id.removeprefix("file_").replace("_", "/")
         parts = workspace.split("/")
         return "/".join(parts[-PATH_COMPONENTS_SHORT:]) if len(parts) > PATH_COMPONENTS_SHORT else workspace
 
@@ -372,9 +424,7 @@ def _is_orphaned_workspace(cmdline: str) -> bool:
     if not workspace_match:
         return False
 
-    workspace_id = workspace_match.group(1)
-    workspace_path = workspace_id.replace("file_", "").replace("_", "/")
-    return not Path("/" + workspace_path).exists()
+    return _resolve_workspace_path(workspace_match.group(1)) is None
 
 
 def capture_ls_snapshot(proc_infos: list[ProcessInfo], windsurf_version: str, windsurf_uptime: float) -> LsSnapshot:
@@ -481,9 +531,13 @@ def _check_orphaned_workspace_proc(cmdline: str, proc: psutil.Process) -> str | 
     database_dir = database_match.group(1)
 
     # Convert workspace_id to actual path
-    workspace_path = workspace_id.replace("file_", "").replace("_", "/")
-    workspace_path_obj = Path("/" + workspace_path)
+    resolved = _resolve_workspace_path(workspace_id)
+    if resolved is not None and resolved.exists():
+        return None
 
+    # Fallback: naïve decode for display/check
+    workspace_path = workspace_id.removeprefix("file_").replace("_", "/")
+    workspace_path_obj = Path("/" + workspace_path)
     if workspace_path_obj.exists():
         return None
 
@@ -498,7 +552,10 @@ def _check_orphaned_workspace_proc(cmdline: str, proc: psutil.Process) -> str | 
     with contextlib.suppress(psutil.NoSuchProcess, psutil.AccessDenied):
         mem_mb = proc.memory_info().rss / 1024 / 1024
 
-    workspace_short = "/".join(workspace_path.split("/")[-3:]) if "/" in workspace_path else workspace_path
+    if resolved is not None:
+        workspace_short = "/".join(resolved.parts[-3:])
+    else:
+        workspace_short = "/".join(workspace_path.split("/")[-3:]) if "/" in workspace_path else workspace_path
     return (
         f"✖  CRITICAL: Language server indexing non-existent workspace '{workspace_short}' "
         f"(consuming {mem_mb:.0f} MB RAM, {db_size_mb:.0f} MB disk) - "

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -14,10 +14,13 @@ from surfmon.monitor import (
     PtyInfo,
     SystemInfo,
     _extract_windsurf_version,
+    _extract_workspace_from_cmdline,
     _get_system_pty_limit,
     _get_windsurf_uptime,
     _group_entries_by_pid,
+    _is_orphaned_workspace,
     _parse_lsof_line,
+    _resolve_workspace_path,
     check_log_issues,
     check_pty_leak,
     count_extensions,
@@ -1672,31 +1675,96 @@ class TestDetectLanguage:
         assert _detect_language(cmdline) == expected
 
 
+def _patch_fs(monkeypatch, dirs, files=()):
+    """Patch Path.is_dir and Path.exists for deterministic resolver tests."""
+    dir_set = {str(Path(d)) for d in dirs}
+    file_set = {str(Path(f)) for f in files}
+
+    monkeypatch.setattr(Path, "is_dir", lambda self: str(self) in dir_set)
+    monkeypatch.setattr(Path, "exists", lambda self: str(self) in dir_set or str(self) in file_set)
+
+
+class TestResolveWorkspacePath:
+    """Tests for Codeium workspace_id resolution (ISM-333)."""
+
+    def test_simple_path_no_hyphens(self, monkeypatch):
+        """All-slash decode works when path has no hyphens or dots."""
+        _patch_fs(monkeypatch, ["/", "/Users", "/Users/dev", "/Users/dev/repos", "/Users/dev/repos/myproject"])
+        assert _resolve_workspace_path("file_Users_dev_repos_myproject") == Path("/Users/dev/repos/myproject")
+
+    def test_hyphenated_directory(self, monkeypatch):
+        """Hyphens in directory names are correctly resolved."""
+        _patch_fs(monkeypatch, ["/", "/Users", "/Users/dev", "/Users/dev/repos", "/Users/dev/repos/copier-uv-bleeding"])
+        assert _resolve_workspace_path("file_Users_dev_repos_copier_uv_bleeding") == Path("/Users/dev/repos/copier-uv-bleeding")
+
+    def test_dotted_file(self, monkeypatch):
+        """Dots in filenames are correctly resolved."""
+        _patch_fs(
+            monkeypatch,
+            ["/", "/Users", "/Users/dev", "/Users/dev/repos"],
+            files=["/Users/dev/repos/project.code-workspace"],
+        )
+        assert _resolve_workspace_path("file_Users_dev_repos_project_code_workspace") == Path("/Users/dev/repos/project.code-workspace")
+
+    def test_ambiguous_with_real_subdir(self, monkeypatch):
+        """Correct resolution when a prefix also exists as a directory."""
+        _patch_fs(
+            monkeypatch,
+            ["/", "/Users", "/Users/dev", "/Users/dev/repos", "/Users/dev/repos/copier", "/Users/dev/repos/copier-uv-bleeding"],
+        )
+        assert _resolve_workspace_path("file_Users_dev_repos_copier_uv_bleeding") == Path("/Users/dev/repos/copier-uv-bleeding")
+
+    def test_truly_orphaned_returns_none(self, monkeypatch):
+        """Returns None for workspace_ids that don't resolve to any real path."""
+        _patch_fs(monkeypatch, ["/", "/Users", "/Users/dev", "/Users/dev/repos"])
+        assert _resolve_workspace_path("file_Users_dev_repos_nonexistent_path") is None
+
+    def test_mixed_dot_and_hyphen(self, monkeypatch):
+        """Handles names with both dots and hyphens."""
+        _patch_fs(monkeypatch, ["/", "/Users", "/Users/dev", "/Users/dev/repos", "/Users/dev/repos/my-app.v2"])
+        assert _resolve_workspace_path("file_Users_dev_repos_my_app_v2") == Path("/Users/dev/repos/my-app.v2")
+
+    def test_code_workspace_with_real_parent_dir(self, monkeypatch):
+        """surfmon.code-workspace resolves even though surfmon/ is a real dir."""
+        _patch_fs(
+            monkeypatch,
+            ["/", "/Users", "/Users/dev", "/Users/dev/repos", "/Users/dev/repos/surfmon"],
+            files=["/Users/dev/repos/surfmon.code-workspace"],
+        )
+        assert _resolve_workspace_path("file_Users_dev_repos_surfmon_code_workspace") == Path("/Users/dev/repos/surfmon.code-workspace")
+
+
 class TestExtractWorkspaceFromCmdline:
     """Tests for _extract_workspace_from_cmdline helper."""
 
-    def test_extracts_workspace_id(self):
+    def test_extracts_workspace_id(self, monkeypatch):
         """Should extract workspace path from --workspace_id."""
-        from surfmon.monitor import _extract_workspace_from_cmdline
-
+        _patch_fs(monkeypatch, ["/", "/Users", "/Users/ismar", "/Users/ismar/repos", "/Users/ismar/repos/surfmon"])
         cmdline = "language_server_macos_arm --workspace_id file_Users_ismar_repos_surfmon"
         result = _extract_workspace_from_cmdline(cmdline)
         assert result == "ismar/repos/surfmon"
 
     def test_extracts_jdt_data_dir(self):
         """Should extract project name from -data flag."""
-        from surfmon.monitor import _extract_workspace_from_cmdline
-
         cmdline = "jdtls -data /home/user/.cache/jdt/myproject"
         result = _extract_workspace_from_cmdline(cmdline)
         assert result == "myproject"
 
     def test_returns_empty_for_unknown(self):
         """Should return empty string when no workspace can be extracted."""
-        from surfmon.monitor import _extract_workspace_from_cmdline
+        assert not _extract_workspace_from_cmdline("gopls serve")
 
-        result = _extract_workspace_from_cmdline("gopls serve")
-        assert not result
+    def test_resolved_hyphenated_path(self, monkeypatch):
+        _patch_fs(monkeypatch, ["/", "/Users", "/Users/dev", "/Users/dev/repos", "/Users/dev/repos/copier-uv-bleeding"])
+        cmdline = "ls --workspace_id file_Users_dev_repos_copier_uv_bleeding --x"
+        result = _extract_workspace_from_cmdline(cmdline)
+        assert "copier-uv-bleeding" in result
+
+    def test_fallback_for_unresolvable(self, monkeypatch):
+        _patch_fs(monkeypatch, ["/"])
+        cmdline = "ls --workspace_id file_no_such_fake_workspace --x"
+        result = _extract_workspace_from_cmdline(cmdline)
+        assert result == "such/fake/workspace"
 
 
 class TestIsOrphanedWorkspace:
@@ -1704,25 +1772,24 @@ class TestIsOrphanedWorkspace:
 
     def test_not_orphaned_without_workspace_id(self):
         """Should return False when no workspace_id flag present."""
-        from surfmon.monitor import _is_orphaned_workspace
-
         assert _is_orphaned_workspace("gopls serve") is False
 
-    def test_not_orphaned_for_existing_workspace(self, mocker):
+    def test_not_orphaned_for_existing_workspace(self, monkeypatch):
         """Should return False for existing workspace path."""
-        from surfmon.monitor import _is_orphaned_workspace
-
-        # Mock Path.exists to avoid platform-specific path issues (e.g. /tmp doesn't exist on Windows)
-        mocker.patch("surfmon.monitor.Path.exists", return_value=True)
-        cmdline = "language_server --workspace_id file_tmp"
+        _patch_fs(monkeypatch, ["/", "/opt"])
+        cmdline = "language_server --workspace_id file_opt"
         assert _is_orphaned_workspace(cmdline) is False
 
-    def test_orphaned_for_nonexistent_workspace(self):
+    def test_orphaned_for_nonexistent_workspace(self, monkeypatch):
         """Should return True for non-existent workspace path."""
-        from surfmon.monitor import _is_orphaned_workspace
-
+        _patch_fs(monkeypatch, ["/"])
         cmdline = "language_server --workspace_id file_Users_nobody_nonexistent_project_xyz"
         assert _is_orphaned_workspace(cmdline) is True
+
+    def test_not_orphaned_with_hyphenated_path(self, monkeypatch):
+        _patch_fs(monkeypatch, ["/", "/Users", "/Users/dev", "/Users/dev/repos", "/Users/dev/repos/my-project"])
+        cmdline = "language_server --workspace_id file_Users_dev_repos_my_project --other"
+        assert _is_orphaned_workspace(cmdline) is False
 
 
 class TestCaptureLsSnapshot:


### PR DESCRIPTION


Closes ISM-XXX

<!-- Replace ISM-XXX with the Linear issue this PR closes (auto-transitions to Done on merge).
     Use "Ref ISM-XXX" to link without closing. Delete the line for chore PRs with no issue. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/surfmon/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
