### PR TITLE
feat: add --json output to history and trend commands

### DIFF
--- a/src/surfmon/cli.py
+++ b/src/surfmon/cli.py
@@ -72,7 +72,7 @@ DEFAULT_REPORTS_DIR = Path.home() / ".surfmon" / "reports"
 DEFAULT_WATCH_DIR = DEFAULT_REPORTS_DIR / "watch"
 
 
-def _print_json(data: dict) -> None:
+def _print_json(data: dict | list) -> None:
     """Print data as JSON to stdout for agent/pipe consumption."""
     print(json.dumps(data, indent=2, default=str))
 
@@ -517,6 +517,7 @@ def history(
     ] = None,
     limit: Annotated[int, typer.Option("--limit", "-n", help="Number of recent sessions to show")] = 20,
     since: Annotated[str | None, typer.Option("--since", "-s", help="Show sessions since duration (e.g. 24h, 7d, 2w)")] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON to stdout (for agent/pipe consumption)")] = False,
 ) -> None:
     """Show recent monitoring sessions from the historical database.
 
@@ -527,13 +528,23 @@ def history(
     try:
         rows = query_history_dicts(db, command=command_filter, limit=limit, since=since)
     except ValueError as exc:
+        if json_output:
+            _print_json({"error": str(exc)})
+            raise typer.Exit(code=1) from exc
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc
 
     if not rows:
+        if json_output:
+            _print_json([])
+            return
         console.print("[yellow]No sessions found in the database.[/yellow]")
         console.print("[dim]Run 'surfmon check', 'surfmon ls-snapshot', or 'surfmon pty-snapshot' to populate it.[/dim]")
         raise typer.Exit(code=0)
+
+    if json_output:
+        _print_json(rows)
+        return
 
     table = make_table(f"Recent Sessions ({len(rows)})")
     table.add_column("Timestamp", style="dim")
@@ -576,6 +587,7 @@ def trend(
     since: Annotated[str | None, typer.Option("--since", "-s", help="Show data since duration (e.g. 24h, 7d, 2w)")] = None,
     plot: Annotated[bool, typer.Option("--plot", "-p", help="Generate a matplotlib chart")] = False,
     output: Annotated[Path | None, typer.Option("--output", "-o", help="Save plot to file")] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON to stdout (for agent/pipe consumption)")] = False,
 ) -> None:
     """Show time-series trends for a metric from the historical database.
 
@@ -586,13 +598,23 @@ def trend(
     try:
         data = query_trend(db, metric=metric, since=since)
     except ValueError as exc:
+        if json_output:
+            _print_json({"error": str(exc)})
+            raise typer.Exit(code=1) from exc
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc
 
     if not data:
+        if json_output:
+            _print_json([])
+            return
         console.print(f"[yellow]No data found for metric '{metric}'.[/yellow]")
         console.print("[dim]Run 'surfmon check' or other commands to populate the database.[/dim]")
         raise typer.Exit(code=0)
+
+    if json_output:
+        _print_json(data)
+        return
 
     # Table display
     table = make_table(f"Trend: {metric} ({len(data)} data points)")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1411,6 +1411,55 @@ class TestHistoryCommand:
         result = runner.invoke(app, ["history"])
         assert result.exit_code == 0
 
+    def test_history_json_with_data(self, mocker):
+        """Should output JSON array when --json is passed."""
+        mocker.patch("surfmon.cli.get_db")
+        mocker.patch(
+            "surfmon.cli.query_history_dicts",
+            return_value=[
+                {
+                    "id": "abc-123",
+                    "timestamp": "2025-01-01T10:00:00+00:00",
+                    "command": "check",
+                    "windsurf_version": "1.95.0",
+                    "windsurf_target": "stable",
+                    "windsurf_uptime_s": 3600.0,
+                    "surfmon_version": "0.6.0",
+                    "process_count": 5,
+                    "total_memory_mb": 2048.0,
+                    "ls_count": 2,
+                    "ls_memory_mb": 500.0,
+                    "orphaned_count": 0,
+                    "pty_count": 25,
+                    "issue_count": 0,
+                },
+            ],
+        )
+        result = runner.invoke(app, ["history", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 1
+        assert data[0]["id"] == "abc-123"
+        assert data[0]["ls_memory_mb"] == 500.0
+
+    def test_history_json_empty(self, mocker):
+        """Should output empty JSON array when no data."""
+        mocker.patch("surfmon.cli.get_db")
+        mocker.patch("surfmon.cli.query_history_dicts", return_value=[])
+        result = runner.invoke(app, ["history", "--json"])
+        assert result.exit_code == 0
+        assert json.loads(result.output) == []
+
+    def test_history_json_error(self, mocker):
+        """Should output JSON error object when ValueError is raised in --json mode."""
+        mocker.patch("surfmon.cli.get_db")
+        mocker.patch("surfmon.cli.query_history_dicts", side_effect=ValueError("Invalid duration format: 'xyz'"))
+        result = runner.invoke(app, ["history", "--json", "--since", "xyz"])
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert "error" in data
+        assert "Invalid duration format" in data["error"]
+
 
 class TestTrendCommand:
     """Tests for the trend command."""
@@ -1469,6 +1518,40 @@ class TestTrendCommand:
         )
         result = runner.invoke(app, ["trend", "memory"])
         assert result.exit_code == 0
+
+    def test_trend_json_with_data(self, mocker):
+        """Should output JSON array when --json is passed."""
+        mocker.patch("surfmon.cli.get_db")
+        mocker.patch(
+            "surfmon.cli.query_trend",
+            return_value=[
+                {"timestamp": "2025-01-01T10:00:00", "value": 1500.0},
+                {"timestamp": "2025-01-01T11:00:00", "value": 1800.0},
+            ],
+        )
+        result = runner.invoke(app, ["trend", "memory", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data) == 2
+        assert data[0]["value"] == 1500.0
+
+    def test_trend_json_empty(self, mocker):
+        """Should output empty JSON array when no data."""
+        mocker.patch("surfmon.cli.get_db")
+        mocker.patch("surfmon.cli.query_trend", return_value=[])
+        result = runner.invoke(app, ["trend", "memory", "--json"])
+        assert result.exit_code == 0
+        assert json.loads(result.output) == []
+
+    def test_trend_json_error(self, mocker):
+        """Should output JSON error object when ValueError is raised in --json mode."""
+        mocker.patch("surfmon.cli.get_db")
+        mocker.patch("surfmon.cli.query_trend", side_effect=ValueError("Unknown metric: 'bogus'"))
+        result = runner.invoke(app, ["trend", "bogus", "--json"])
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert "error" in data
+        assert "Unknown metric" in data["error"]
 
 
 class TestTrendHelpers:

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -650,21 +650,19 @@ class TestCountWindsurfLaunchesToday:
 
     def test_counts_todays_launches(self, tmp_path, monkeypatch):
         """Should count only log directories from today."""
-        from datetime import datetime
+        from datetime import UTC, datetime, timedelta
 
         log_base = tmp_path / "Library" / "Application Support" / "Windsurf" / "logs"
         log_base.mkdir(parents=True)
 
-        # Create log directories for today
-        today_str = datetime.now().strftime("%Y%m%d")
+        # Create log directories for today (UTC, matching production code)
+        today_str = datetime.now(tz=UTC).strftime("%Y%m%d")
         (log_base / f"{today_str}T120000").mkdir()
         (log_base / f"{today_str}T130000").mkdir()
         (log_base / f"{today_str}T140000").mkdir()
 
         # Create a log directory from yesterday
-        from datetime import timedelta
-
-        yesterday = datetime.now() - timedelta(days=1)
+        yesterday = datetime.now(tz=UTC) - timedelta(days=1)
         yesterday_str = yesterday.strftime("%Y%m%d")
         (log_base / f"{yesterday_str}T120000").mkdir()
 
@@ -1303,12 +1301,12 @@ class TestLaunchCountEdgeCases:
 
     def test_skips_non_directory_entries(self, tmp_path, monkeypatch):
         """Should skip non-directory entries in logs folder."""
-        from datetime import datetime
+        from datetime import UTC, datetime
 
         log_base = tmp_path / "Library" / "Application Support" / "Windsurf" / "logs"
         log_base.mkdir(parents=True)
 
-        today_str = datetime.now().strftime("%Y%m%d")
+        today_str = datetime.now(tz=UTC).strftime("%Y%m%d")
         (log_base / f"{today_str}T120000").mkdir()
         # Create a file (not directory) - should be skipped
         (log_base / f"{today_str}T130000.log").touch()
@@ -1321,12 +1319,12 @@ class TestLaunchCountEdgeCases:
 
     def test_skips_malformed_directory_names(self, tmp_path, monkeypatch):
         """Should skip directories with malformed names."""
-        from datetime import datetime
+        from datetime import UTC, datetime
 
         log_base = tmp_path / "Library" / "Application Support" / "Windsurf" / "logs"
         log_base.mkdir(parents=True)
 
-        today_str = datetime.now().strftime("%Y%m%d")
+        today_str = datetime.now(tz=UTC).strftime("%Y%m%d")
         (log_base / f"{today_str}T120000").mkdir()
         # Create directories with malformed names
         (log_base / "invalid-name").mkdir()


### PR DESCRIPTION
Closes #74
Closes #75

Adds `--json` flag to `surfmon history` and `surfmon trend` commands for machine-readable output, matching the existing `--json` support in `check`, `ls-snapshot`, and `pty-snapshot`.

Also fixes:
- `_print_json` type hint widened from `dict` to `dict | list`
- 3 timezone bugs in `count_windsurf_launches_today` tests (naive `datetime.now()` vs UTC comparison)