### PR TITLE
fix: resolve iCloud workspace paths with spaces and tildes

### DIFF
--- a/src/surfmon/workspaces.py
+++ b/src/surfmon/workspaces.py
@@ -23,9 +23,11 @@ class WorkspaceInfo:
 # Workspace path resolution
 # ---------------------------------------------------------------------------
 
+_MIN_HEX_LEN = 2  # minimum chars for a percent-encoded sequence (e.g. _20 → space)
+
 
 def _try_joiners(base: Path, segments: list[str]) -> Path | None:
-    """Try ``/``, ``-``, and ``.`` for each underscore between *segments*."""
+    """Try ``/``, ``-``, ``.``, ``~``, and percent-decoded chars for each underscore."""
     if len(segments) == 1:
         candidate = base / segments[0]
         return candidate if candidate.exists() else None
@@ -39,12 +41,28 @@ def _try_joiners(base: Path, segments: list[str]) -> Path | None:
         if result is not None:
             return result
 
-    # Option 2/3: underscore was - or . (merge with next segment)
-    for joiner in ("-", "."):
+    # Option 2/3/4: underscore was -, ., or ~ (merge with next segment)
+    for joiner in ("-", ".", "~"):
         merged = [first + joiner + rest[0], *rest[1:]]
         result = _try_joiners(base, merged)
         if result is not None:
             return result
+
+    # Option 5: percent-encoded character (_XX where XX is hex)
+    # Codeium URL-encodes special chars (e.g. space → %20) then replaces % with _,
+    # so _20 in the workspace_id represents a literal space in the path.
+    if len(rest[0]) >= _MIN_HEX_LEN:
+        hex_prefix = rest[0][:_MIN_HEX_LEN]
+        try:
+            decoded_char = chr(int(hex_prefix, 16))
+        except ValueError:
+            decoded_char = ""
+        if decoded_char and decoded_char.isprintable():
+            suffix = rest[0][_MIN_HEX_LEN:]
+            merged = [first + decoded_char + suffix, *rest[1:]]
+            result = _try_joiners(base, merged)
+            if result is not None:
+                return result
 
     return None
 
@@ -52,14 +70,16 @@ def _try_joiners(base: Path, segments: list[str]) -> Path | None:
 def _resolve_workspace_path(workspace_id: str) -> Path | None:
     """Resolve a Codeium workspace_id to an existing filesystem path.
 
-    Codeium encodes ``/``, ``-``, and ``.`` as ``_`` in its ``--workspace_id``
-    argument.  A naïve ``replace("_", "/")`` produces false paths for any
-    directory whose name contains hyphens or dots (e.g. ``copier-uv-bleeding``
-    becomes ``copier/uv/bleeding``).
+    Codeium encodes ``/``, ``-``, ``.``, and ``~`` as ``_`` in its
+    ``--workspace_id`` argument, and URL-encodes other special characters
+    (e.g. space → ``%20``) with ``%`` also replaced by ``_`` (so space
+    becomes ``_20``).  A naïve ``replace("_", "/")`` produces false paths
+    for any directory whose name contains hyphens, dots, tildes, or spaces.
 
-    This function walks the filesystem, trying ``/``, ``-``, and ``.`` for each
-    encoded underscore until it finds a path that actually exists.  Returns
-    ``None`` when no valid decoding is found (truly orphaned workspace).
+    This function walks the filesystem, trying ``/``, ``-``, ``.``, ``~``,
+    and percent-decoded characters for each encoded underscore until it finds
+    a path that actually exists.  Returns ``None`` when no valid decoding is
+    found (truly orphaned workspace).
     """
     raw = workspace_id.removeprefix("file_")
     segments = raw.split("_")

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -21,7 +21,26 @@ _LOG_TS_2 = "20260314T120000"
 _DEV_HOME = "/Users/dev"
 _DEV_REPOS = "/Users/dev/repos"
 _COPIER_UV = "/Users/dev/repos/copier-uv-bleeding"
+_ICLOUD_BASE = "/Users/dev/Library"
+_ICLOUD_MOBILE = "/Users/dev/Library/Mobile Documents"
+_ICLOUD_APPLE = "/Users/dev/Library/Mobile Documents/com~apple~CloudDocs"
+_ICLOUD_DOCS = "/Users/dev/Library/Mobile Documents/com~apple~CloudDocs/Documents"
+_ICLOUD_CAREER = "/Users/dev/Library/Mobile Documents/com~apple~CloudDocs/Documents/Career"
+_ICLOUD_JOBS = "/Users/dev/Library/Mobile Documents/com~apple~CloudDocs/Documents/Career/Job Applications"
+_ICLOUD_PROJECT = "/Users/dev/Library/Mobile Documents/com~apple~CloudDocs/Documents/Career/Job Applications/digitec-galaxus"
 _FS_BASE = ["/", "/Users", _DEV_HOME, _DEV_REPOS]
+_FS_ICLOUD = [
+    "/",
+    "/Users",
+    _DEV_HOME,
+    _ICLOUD_BASE,
+    _ICLOUD_MOBILE,
+    _ICLOUD_APPLE,
+    _ICLOUD_DOCS,
+    _ICLOUD_CAREER,
+    _ICLOUD_JOBS,
+    _ICLOUD_PROJECT,
+]
 
 
 def _patch_fs(monkeypatch, dirs, files=()):
@@ -287,6 +306,29 @@ class TestResolveWorkspacePath:
             files=[f"{_DEV_REPOS}/surfmon.code-workspace"],
         )
         assert _resolve_workspace_path("file_Users_dev_repos_surfmon_code_workspace") == Path("/Users/dev/repos/surfmon.code-workspace")
+
+    def test_tilde_directory(self, monkeypatch):
+        """Tildes in directory names are correctly resolved (iCloud paths)."""
+        _patch_fs(
+            monkeypatch,
+            ["/", "/Users", _DEV_HOME, _ICLOUD_BASE, _ICLOUD_MOBILE, _ICLOUD_APPLE],
+        )
+        result = _resolve_workspace_path("file_Users_dev_Library_Mobile_20Documents_com_apple_CloudDocs")
+        assert result == Path(_ICLOUD_APPLE)
+
+    def test_icloud_path_with_spaces_and_tildes(self, monkeypatch):
+        """Full iCloud path with spaces (_20) and tildes resolves correctly."""
+        _patch_fs(monkeypatch, _FS_ICLOUD)
+        workspace_id = "file_Users_dev_Library_Mobile_20Documents_com_apple_CloudDocs_Documents_Career_Job_20Applications_digitec_galaxus"
+        assert _resolve_workspace_path(workspace_id) == Path(_ICLOUD_PROJECT)
+
+    def test_icloud_path_not_orphaned(self, monkeypatch):
+        """An existing iCloud workspace must not be flagged as orphaned."""
+        _patch_fs(monkeypatch, _FS_ICLOUD)
+        workspace_id = "file_Users_dev_Library_Mobile_20Documents_com_apple_CloudDocs_Documents_Career_Job_20Applications_digitec_galaxus"
+        result = _resolve_workspace_path(workspace_id)
+        assert result is not None
+        assert result == Path(_ICLOUD_PROJECT)
 
 
 class TestExtractWorkspaceFromCmdline:


### PR DESCRIPTION
Closes DET-20

## Summary

`_resolve_workspace_path` produced false-positive orphan detections for workspaces in iCloud Drive paths containing spaces or tildes.

**Root cause:** `_try_joiners` only tried `/`, `-`, `.` as joiner characters. Codeium also encodes:
- `~` as `_` (iCloud paths like `com~apple~CloudDocs`)
- Space as `_20` (URL-encoding `%20` with `%` → `_`)

**Fix:** Added `~` to the joiner list and percent-decoding logic (`_XX` → decoded char) to `_try_joiners`. Three new tests covering iCloud paths with tildes and spaces.