### PR TITLE
fix: skip orphan detection for untitled workspace IDs

### DIFF
--- a/src/surfmon/monitor.py
+++ b/src/surfmon/monitor.py
@@ -343,7 +343,7 @@ def _build_ls_entry(
     else:
         workspace = _extract_workspace_from_cmdline(original_proc.cmdline)
 
-    orphaned = workspace_id is not None and resolved_path is None
+    orphaned = workspace_id is not None and workspace_id.startswith("file_") and resolved_path is None
     stale = not orphaned and bool(active_ws_paths) and resolved_path is not None and str(resolved_path) not in active_ws_paths
 
     entry = LsSnapshotEntry(

--- a/src/surfmon/workspaces.py
+++ b/src/surfmon/workspaces.py
@@ -81,6 +81,8 @@ def _resolve_workspace_path(workspace_id: str) -> Path | None:
     a path that actually exists.  Returns ``None`` when no valid decoding is
     found (truly orphaned workspace).
     """
+    if not workspace_id.startswith("file_"):
+        return None
     raw = workspace_id.removeprefix("file_")
     segments = raw.split("_")
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -878,6 +878,29 @@ class TestCaptureLsSnapshot:
         assert snapshot.issues[0].severity == IssueSeverity.CRITICAL
         assert snapshot.entries[0].orphaned is True
 
+    def test_untitled_workspace_not_orphaned(self):
+        """Untitled (unsaved) workspaces must not be flagged as orphaned."""
+        from surfmon.monitor import ProcessInfo, capture_ls_snapshot
+
+        proc_infos = [
+            ProcessInfo(
+                2000,
+                _LS_BINARY,
+                10.0,
+                800.0,
+                2.5,
+                8,
+                3500.0,
+                "language_server_macos_arm --workspace_id untitled_1773689340397",
+            ),
+        ]
+
+        snapshot = capture_ls_snapshot(proc_infos, "2.5.0", 3600.0)
+
+        assert snapshot.orphaned_count == 0
+        assert len(snapshot.issues) == 0
+        assert snapshot.entries[0].orphaned is False
+
     def test_empty_when_no_language_servers(self):
         """Should return empty snapshot when no language servers found."""
         from surfmon.monitor import ProcessInfo, capture_ls_snapshot

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -330,6 +330,14 @@ class TestResolveWorkspacePath:
         assert result is not None
         assert result == Path(_ICLOUD_PROJECT)
 
+    def test_untitled_workspace_returns_none(self):
+        """Untitled (unsaved) workspaces have no filesystem path."""
+        assert _resolve_workspace_path("untitled_1773689340397") is None
+
+    def test_non_file_prefix_returns_none(self):
+        """Workspace IDs without the file_ prefix are not filesystem-based."""
+        assert _resolve_workspace_path("vscode-remote_wsl_project") is None
+
 
 class TestExtractWorkspaceFromCmdline:
     """Tests for _extract_workspace_from_cmdline helper."""


### PR DESCRIPTION
## Summary

Untitled (unsaved) workspaces use workspace IDs like `untitled_1773689340397` — no `file_` prefix. `_resolve_workspace_path` tried to resolve these as filesystem paths, failed, and the LS got flagged as orphaned even though the workspace was actively open.

## Changes

- **`_resolve_workspace_path`**: early return `None` for non-`file_` prefixed workspace IDs
- **`_build_ls_entry`**: guard orphan detection with `workspace_id.startswith("file_")` (defense in depth)
- **Tests**: 2 new tests for untitled and non-file workspace IDs

Closes DET-21