### PR TITLE
feat: friendly display for non-file workspace IDs

### DIFF
--- a/src/surfmon/workspaces.py
+++ b/src/surfmon/workspaces.py
@@ -111,7 +111,11 @@ def _format_workspace_display(workspace_id: str, resolved: Path | None) -> str:
     if resolved is not None:
         parts = resolved.parts
         return "/".join(parts[-PATH_COMPONENTS_SHORT:]) if len(parts) > PATH_COMPONENTS_SHORT else str(resolved)
-    # Fallback: naïve decode for display
+    # Non-file workspaces (e.g. untitled_1773689340397) get a friendly label
+    if not workspace_id.startswith("file_"):
+        prefix, _, suffix = workspace_id.partition("_")
+        return f"{prefix} ({suffix})" if suffix else prefix
+    # Fallback: naïve decode for display of unresolvable file_ workspace IDs
     workspace = workspace_id.removeprefix("file_").replace("_", "/")
     parts = workspace.split("/")
     return "/".join(parts[-PATH_COMPONENTS_SHORT:]) if len(parts) > PATH_COMPONENTS_SHORT else workspace

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 
 from surfmon.workspaces import (
     _extract_workspace_from_cmdline,
+    _format_workspace_display,
     _parse_workspace_event,
     _resolve_workspace_path,
     count_windsurf_launches_today,
@@ -337,6 +338,35 @@ class TestResolveWorkspacePath:
     def test_non_file_prefix_returns_none(self):
         """Workspace IDs without the file_ prefix are not filesystem-based."""
         assert _resolve_workspace_path("vscode-remote_wsl_project") is None
+
+
+class TestFormatWorkspaceDisplay:
+    """Tests for _format_workspace_display friendly labels."""
+
+    def test_resolved_path_uses_short_format(self):
+        """Resolved paths are shortened to last N components."""
+        result = _format_workspace_display("file_Users_dev_repos_surfmon", Path("/Users/dev/repos/surfmon"))
+        assert result == "dev/repos/surfmon"
+
+    def test_untitled_workspace_friendly_label(self):
+        """Untitled workspace IDs get a friendly parenthesized label."""
+        result = _format_workspace_display("untitled_1773689340397", None)
+        assert result == "untitled (1773689340397)"
+
+    def test_non_file_prefix_friendly_label(self):
+        """Other non-file prefixes get a friendly label."""
+        result = _format_workspace_display("vscode-remote_wsl_project", None)
+        assert result == "vscode-remote (wsl_project)"
+
+    def test_bare_prefix_no_suffix(self):
+        """A workspace ID with no underscore returns the raw prefix."""
+        result = _format_workspace_display("untitled", None)
+        assert result == "untitled"
+
+    def test_unresolvable_file_workspace_falls_back(self):
+        """Unresolvable file_ workspace IDs use naïve slash decode."""
+        result = _format_workspace_display("file_Users_dev_repos_gone", None)
+        assert result == "dev/repos/gone"
 
 
 class TestExtractWorkspaceFromCmdline:


### PR DESCRIPTION
## Summary

Non-file workspace IDs (e.g. `untitled_1773689340397`) were displayed as path-like strings (`untitled/1773689340397`) due to the naïve `replace("_", "/")` fallback in `_format_workspace_display`. Now they get friendly parenthesized labels like `untitled (1773689340397)`.

## Changes

- **`_format_workspace_display`**: detect non-`file_` workspace IDs and format as `prefix (suffix)` instead of path-like slash decode
- **Tests**: 5 new tests covering untitled, other non-file prefixes, bare prefix, resolved path, and unresolvable file_ fallback

## Before / After

| Workspace ID | Before | After |
|---|---|---|
| `untitled_1773689340397` | `untitled/1773689340397` | `untitled (1773689340397)` |
| `vscode-remote_wsl_project` | `vscode-remote/wsl/project` | `vscode-remote (wsl_project)` |

Closes DET-22